### PR TITLE
Neaten MainCtrl

### DIFF
--- a/Client/styles/main.css
+++ b/Client/styles/main.css
@@ -1,4 +1,11 @@
+* {
+  /* if I have to ctrlc ctrlv this one more time... */
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+}
+
+
 /* Search Panel */
+
 html div#search_panel {
 	padding-bottom: unset;
 }
@@ -57,14 +64,12 @@ html, body {
   overflow: hidden;
   transition-property: right;
   transition-duration: .5s;
-  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
 
 #main-panel.open {
   right: 150px;
   transition-property: right;
   transition-duration: .5s;
-  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
 
 .page-content {
@@ -152,13 +157,10 @@ input, textarea {
   width: 100%;
   box-shadow: 0px 0px 5px #999;
   transition-property: bottom;
-  transition-duration: 0.2s;
-  transition-timing-function: cubic-bezier(1,0,0,1);
-}
-
-.writer.writerClosed {
+  transition-duration: 0.5s;
   bottom: -145px;
 }
+
 .writer.writerOpen {
   bottom: 0px;
 }
@@ -203,9 +205,8 @@ input, textarea {
 
 
 .contribute {
-  position: fixed;
-  position: fixed;
-  bottom: 55px;
+  position: absolute;
+  top: -55px;
   right: 90px;
   z-index: 20;
   height: 60px;
@@ -215,8 +216,14 @@ input, textarea {
   font-size: 43px;
   color: #fff;
   cursor: pointer;
-  box-shadow: 0px 4px 4px #999;
+  box-shadow: 0px 4px 4px rgba(0,0,0,0.6);
   margin-right: -30px;
+  transition: right;
+  transition-duration: 0.2s;
+}
+
+.writer.writerOpen .contribute {
+  right: 50%;
 }
 
 .ask {
@@ -269,6 +276,7 @@ input, textarea {
   position: absolute;
   z-index: 10;
   background: #fff;
+  transform: rotate(0deg);
 }
 
 #cross:before {
@@ -286,9 +294,6 @@ input, textarea {
   width: 100%;
 }
 #cross.writerOpen {
-  transform: rotate(45deg);
-}
-#cross.writerClosed {
   transform: rotate(45deg);
 }
 

--- a/Client/styles/main.css
+++ b/Client/styles/main.css
@@ -147,12 +147,20 @@ input, textarea {
 
 .writer {
   position: fixed;
-  bottom: -145px;
   left: 0;
   background-color: #eee;
   width: 100%;
   box-shadow: 0px 0px 5px #999;
+  transition-property: bottom;
+  transition-duration: 0.2s;
+  transition-timing-function: cubic-bezier(1,0,0,1);
+}
 
+.writer.writerClosed {
+  bottom: -145px;
+}
+.writer.writerOpen {
+  bottom: 0px;
 }
 
  .writer input, textarea {
@@ -276,6 +284,12 @@ input, textarea {
   margin-top: -7%;
   margin-left: -50%;
   width: 100%;
+}
+#cross.writerOpen {
+  transform: rotate(45deg);
+}
+#cross.writerClosed {
+  transform: rotate(45deg);
 }
 
 

--- a/Client/views/main.html
+++ b/Client/views/main.html
@@ -80,12 +80,13 @@
 					</div>
 				</div>
 				
-				<div class="contribute-container">
-					<div id="add-button" class="contribute ask" ng-click="qc.toggleWriter()">
-						<div id="cross"></div>
-					</div>
-				</div>
+
 				<div class="writer" ng-class="{writerOpen: qc.writerOpen}">
+					<div class="contribute-container">
+						<div id="add-button" class="contribute ask" ng-click="qc.toggleWriter()">
+							<div id="cross" ng-class="{writerOpen: qc.writerOpen}"></div>
+						</div>
+					</div>
 					<div class="container">
 						<div class="input-box-container" ng-init="newPost.title = ''; newPost.author = ''; newPost.message = ''">
 							<input name="title" ng-model="newPost.title" placeholder="title">

--- a/Client/views/main.html
+++ b/Client/views/main.html
@@ -18,23 +18,23 @@
 	<div class="page">
 		<div class="page-content">
 			<!-- Search panel -->
-			<div ng-init="debug=true" ng-controller="SearchController as searchCtrl" id="search_panel" class="row card">
+			<div ng-init="debug=true" ng-controller="SearchController as search" id="search_panel" class="row card">
 				<div class="row">
 					<div class="col-sm-4">
 						<div class="form-group form-group-sm input-group">
-							<label class="input-group-addon">Topic: </label>
+							<label class="input-group-addon" ng-model="search.criteria.topic">Topic: </label>
 							<input ng-model="form.topic" type="text" placeholder="the Topic of Question" class="form-control input-sm">
 						</div>
 					</div>
 					<div class="col-sm-3">
 						<div class="form-group form-group-sm input-group">
-							<label class="input-group-addon">Name: </label>
+							<label class="input-group-addon" ng-model="search.criteria.name">Name: </label>
 							<input ng-model="form.name" type="text" placeholder="the Name of Author" class="form-control input-sm">
 						</div>
 					</div>
 					<div class="col-sm-3">
 						<div class="form-group form-group-sm input-group">
-							<label class="input-group-addon">Date: </label>
+							<label class="input-group-addon" ng-model="search.criteria.date">Date: </label>
 							<input ng-model="form.date" type="text" placeholder="the Date of Question" class="form-control input-sm">
 						</div>
 					</div>
@@ -46,15 +46,15 @@
 				<pre ng-show="debug">backend = {{criteria | json}}</pre>
 			</div>
 				
-			<div id="questionList" ng-controller="QuestionListController as questionCtrl">
+			<div id="questionList" ng-controller="QuestionListController as qc">
 				<!-- Question Listing -->
-				<div class="row card" ng-repeat="question in questionCtrl.questions.questionList | orderBy:questionCtrl.getScore | filter:searchAuthor">
+				<div class="row card" ng-repeat="question in qc.questions.questionsList">
 					<div class="score">
-						<img class="upvote" src="../images/upvote.png" ng-click="questionCtrl.upVote(question._id)">
-						<br>
-							{{ question.upVotes - question.downVotes }}
-						<br> 
-						<img class="downvote" src="../images/dnvote.png" ng-click="questionCtrl.downVote(question._id)">
+						<img class="upvote" src="../images/upvote.png" ng-click="question.upVote()">
+						<br/>
+							{{ question.score }}
+						<br/> 
+						<img class="downvote" src="../images/dnvote.png" ng-click="question.downVote()">
 					</div>
 					<div class="title">
 						<a href="#/question/{{question._id}}">{{ question.title }}</a>
@@ -67,7 +67,7 @@
 				<div id="loadingImage" ng-include="'views/loadingImage.html'"></div>
 		
 				<!-- New Question -->
-				<div ng-show="questionCtrl.writerOpen === true" class="row card">
+				<div ng-show="qc.writerOpen === true" class="row card">
 					<div class="col-sm-2">
 						<div ng-hide="newPost.title===''"><strong>Title: </strong></div>
 						<div ng-hide="newPost.author===''"><strong>Author: </strong></div>
@@ -81,18 +81,18 @@
 				</div>
 				
 				<div class="contribute-container">
-					<div id="add-button" class="contribute ask" ng-click="questionCtrl.writerOpen === true ? questionCtrl.closeWriter() : questionCtrl.openWriter()">
+					<div id="add-button" class="contribute ask" ng-click="qc.toggleWriter()">
 						<div id="cross"></div>
 					</div>
 				</div>
-				<div ng-show="questionCtrl.writerOpen === true" class="writer">
+				<div class="writer" ng-class="{writerOpen: qc.writerOpen}">
 					<div class="container">
 						<div class="input-box-container" ng-init="newPost.title = ''; newPost.author = ''; newPost.message = ''">
 							<input name="title" ng-model="newPost.title" placeholder="title">
 							<input name="author" ng-model="newPost.author" placeholder="posted by">
 							<textarea ng-model="newPost.message" placeholder="question"></textarea>
 						</div>
-						<div ng-click="questionCtrl.addQuestion(newPost)" class="button send-button">
+						<div ng-click="qc.addQuestion(newPost)" class="button send-button">
 							post
 						</div>
 					</div>	


### PR DESCRIPTION
Neatened up the code in MainCtrl heavily - this includes implementing a Question model-controller class that (should) handle most server communication directly. This means we don't have to reimplement it later on if we want to use it in a different view, yay! Also removed all the tmp.me stuff, and moved all style/animations stuff to the view and css where it should be; this will make moving to other frameworks much easier as we won't have to change MainCtrl much, if at all. Finally changed all animations to pure CSS animations instead of jQuery.

This is currently based on my loginService branch, so it includes those commits as well - but I can remove that stuff and base it directly on Master if you don't want to include that stuff.