### PR TITLE
Browse groups!

### DIFF
--- a/Client/app.js
+++ b/Client/app.js
@@ -43,28 +43,13 @@ kusema.config(function (
     .when('','/kusema')
     .when('/','/kusema');
 
-
-  /*
-  .state('/question/:id', {
-    templateUrl: 'user/question/question.html',
-  })
-  .when('/group/:id', {
-    templateUrl: 'user/group/group.html',
-  })
-  .when('/newcomment/:id', {
-	  templateUrl: 'views/newComment.html',
-  })
-  .when('/newquestion/', {
-	  templateUrl: 'views/newQuestion.html',
-  })
-  .when('/newunit/', {
-	  templateUrl: 'views/newUnit.html',
-  })
-  .when('/newarea/', {
-	  templateUrl: 'views/newArea.html',
-  });*/
   
 });
+
+kusema.run(['$rootScope', '$stateParams', function($rootScope, $stateParams) {
+  $rootScope.$stateParams = $stateParams;
+  console.log('hellooooo! :)');
+}]);
 
 /*
 kusema.addModule(string moduleName, dependencies=[], autoRequire=true)

--- a/Client/bower.json
+++ b/Client/bower.json
@@ -2,7 +2,6 @@
   "name": "kusema",
   "version": "0.0.1",
   "dependencies": {
-    "json3": "~3.3.2",
     "es5-shim": "~4.1.10",
     "socket.io-client": "~1.2.0",
     "angular": "~1.4.4",

--- a/Client/common/components/ContentCard/contentCardTemplate.html
+++ b/Client/common/components/ContentCard/contentCardTemplate.html
@@ -33,7 +33,15 @@
 	
 	<md-card-footer>
 		<div class="footer-contents">
-	Posted on <kusema-inline-date date="c.content.dateCreated"></kusema-inline-date>
+			Posted on <kusema-inline-date date="c.content.dateCreated"></kusema-inline-date>
+			<span ng-if="c.content.name == 'Question'">
+				, in <kusema-inline-group group="c.content.group"></kusema-inline-group>.
+			</span>
+			<md-chips ng-model="c.content.topics" readonly="true">
+				<md-chip-template>
+					{{$chip.name}}
+				</md-chip-template>
+			</md-chips>
 		</div>
 		<md-button class="md-icon-button" kusema-needs-login needs-user="c.content.author" ng-click="c.editContent()">
 			<md-icon md-font-set="material-icons">edit</md-icon>

--- a/Client/common/components/EditContentForm/editContentForm.js
+++ b/Client/common/components/EditContentForm/editContentForm.js
@@ -16,13 +16,14 @@ var editContentFormDirective = function() {
     };
 //}
 
-var editContentFormController = function($scope, baseContentService) {
+var editContentFormController = function($scope, baseContentService, groupService) {
         this.$scope = $scope;
         this.baseContentService = baseContentService;
         this.initializeContent();
         this._checkContentType();
         this.actionText = 'asdf'
-
+        $scope.groupService = groupService;
+        this.groupSearchText = '';
         return this;
     }
 
@@ -66,16 +67,21 @@ var editContentFormController = function($scope, baseContentService) {
                 this.content.message = newContent.message;
                 this.content._id = newContent._id;
                 this.content.question = newContent.question;
+                this.content.group = newContent.group;
+                this.content.topics = newContent.topics;
                 this._outsideContent = newContent;
             }
         }
 
     })
 
+
     editContentFormController.prototype.initializeContent = function() {
         this.content = (this.content) ? this.content : {
             title: '',
             message: '',
+            group: null,
+            topics: [],
         };
     }
 
@@ -113,9 +119,16 @@ var editContentFormController = function($scope, baseContentService) {
         return this.contentService.add(this.content);
     }
 
+    editContentFormController.prototype.searchGroups = function(searchText) {
+        console.log(this.groupService.bindables.groups);
+        return this.groupService.bindables.groupsArray;
+    }
+    editContentFormController.prototype.log = function() {
+        console.log('ffs');
+    }
 
 //}
 
 kusema.addModule('kusema.components.editContent')
     .directive('kusemaEditContentForm', editContentFormDirective)
-    .controller('editContentFormController', ['$scope', 'baseContentService', editContentFormController]);
+    .controller('editContentFormController', ['$scope', 'baseContentService', 'groupService', editContentFormController]);

--- a/Client/common/components/EditContentForm/editContentFormTemplate.html
+++ b/Client/common/components/EditContentForm/editContentFormTemplate.html
@@ -1,11 +1,61 @@
 <form ng-submit="c.save()">
+
 <md-input-container ng-if="c.contentType == 'Question'">
 	<label>{{c.contentType}} Subject</label>
 	<input ng-model="c.content.title" />
 </md-input-container>
+
 <md-input-container>
 	<label>Message</label>
 	<textarea ng-model="c.content.message"></textarea>
+</md-input-container>
+
+<md-autocomplete
+	ng-if="c.contentType == 'Question'"
+	md-no-cache="true"
+	md-selected-item="c.content.group"
+	md-search-text = "c.groupSearchText"
+	md-search-text-change = "c.log()"
+	md-selected-item-change = "c.log()"
+	md-min-length=0
+	md-items = "group in groupService.bindables.groupsArray"
+	md-item-text = "group.name"
+  	md-autofocus = "true"
+  	md-floating-label = "Which Group does this Question belong in?"
+	>
+	<md-item-template>
+		<span class="groupCode">
+		{{group.unitCode}}:
+		</span>
+		<span class="groupName">
+		{{group.title}}
+		</span>
+	</md-item-template>
+</md-autocomplete>
+
+<md-chips
+	ng-model = "c.content.topics"
+	ng-if="c.contentType == 'Question'"
+	md-autocomplete-snap
+	md-require-match="true"
+	>
+	<md-autocomplete
+		md-selected-item = "c.selectedTopic"
+		md-search-text = "c.topicSearchText"
+		md-items = "topic in groupService.topicService.bindables.topicsArray"
+		md-item-text = "topic.name"
+		md-floating-label = "Which Topics are relevant to this question?"
+		>
+		<span md-highligt-text="c.topicSearchText">
+		{{topic.name}}
+		</span>
+	</md-autocomplete>
+	<md-chip-template>
+		{{$chip.name}}
+	</md-chip-template>
+</md-chips>
+
+
 </md-input-container>
 <div class="md-actions" layout="row">
 	<md-button type="button" ng-click="onCancel()">Cancel</md-button>

--- a/Client/common/components/InlineDate/inlineDate.js
+++ b/Client/common/components/InlineDate/inlineDate.js
@@ -3,7 +3,7 @@
 var inlineDateDirective = function() {
 		return {
 			bindToController: {
-				'date': '&'
+				'date': '='
 			},
 			scope: {},
 			templateUrl: 'common/components/InlineDate/inlineDate.html',
@@ -13,7 +13,6 @@ var inlineDateDirective = function() {
 	};
 //}
 var inlineDateController = function($scope) {
-		this.date = new Date();
 		return this;
 	}
 	inlineDateController.prototype.format = function($scope) {

--- a/Client/common/components/InlineGroup/inlineGroup.html
+++ b/Client/common/components/InlineGroup/inlineGroup.html
@@ -1,0 +1,1 @@
+<abbr title="{{c.group.name}}" class="unitCode">{{c.group.unitCode}}</abbr

--- a/Client/common/components/InlineGroup/inlineGroup.js
+++ b/Client/common/components/InlineGroup/inlineGroup.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var inlineGroupDirective = function() {
+		return {
+			bindToController: {
+				'group': '='
+			},
+			scope: {},
+			templateUrl: 'common/components/InlineGroup/inlineGroup.html',
+			controller: 'kusemaInlineGroupController',
+			controllerAs: 'c',
+		};
+	};
+//}
+var inlineGroupController = function() {
+		return this;
+	}
+
+	
+kusema.addModule('kusema.components.inlineGroup')
+		.directive('kusemaInlineGroup', inlineGroupDirective)
+		.controller('kusemaInlineGroupController', inlineGroupController);

--- a/Client/common/components/Markdown/markdown.js
+++ b/Client/common/components/Markdown/markdown.js
@@ -34,12 +34,6 @@ markdownController.prototype = Object.create(Object.prototype, {
 markdownController.prototype.updateOutput = function() {
 	if (this.md && this._input) {
 		var renderer = (this.inline) ? this.md.renderInline.bind(this.md) : this.md.render.bind(this.md);
-		if (this.inline) {
-			console.log('rendering inline: '+this.input);
-		} else {
-			console.log('rendering full: '+this.input);
-
-		}
 		this.output = this.$sce.trustAsHtml(renderer(this.input));
 	}
 } 

--- a/Client/common/components/QuestionPreview/questionPreview.css
+++ b/Client/common/components/QuestionPreview/questionPreview.css
@@ -1,4 +1,8 @@
-kusema-question-preview md-card-content {
+kusema-question-preview md-card-content message {
 	max-height: 12em;
 	overflow: hidden;
+}
+/*HACK while md-chips are broken*/
+kusema-question-preview md-chip[index="0"] {
+	background-color: rgb(220, 200, 220);
 }

--- a/Client/common/components/QuestionPreview/questionPreview.js
+++ b/Client/common/components/QuestionPreview/questionPreview.js
@@ -13,7 +13,16 @@ var questionPreviewDirective = function() {
 var questionPreviewController = function($scope) {
 		this.$scope = $scope;
 		this.question = $scope.question;
+		$scope.$watch('question.group', this.updateGrossHackyList.bind(this));
+		$scope.$watch('question.topics', this.updateGrossHackyList.bind(this));
+		this.updateGrossHackyList();
 		return this;
+	}
+
+	questionPreviewController.prototype = Object.create(Object.prototype, {});
+
+	questionPreviewController.prototype.updateGrossHackyList = function() {
+		this.groupsAndTopics = [this.question.group].concat(this.question.topics);
 	}
 	
 kusema.addModule('kusema.components.questionPreview')

--- a/Client/common/components/QuestionPreview/questionPreviewTemplate.html
+++ b/Client/common/components/QuestionPreview/questionPreviewTemplate.html
@@ -4,7 +4,21 @@
 			<h2 class="md-title">{{c.question.title}}</h2>
 		</a>
 		<div class="usernameFloat">{{c.question.author.username}}</div>
-		<div kusema-markdown input="c.question.message"></div>
+		<div class="message" kusema-markdown input="c.question.message"></div>
+		<!-- HACK while md-chips are broken. static chips flat out don't work
+		     and manual ng-repeat is buggy. -->
+		<md-chips ng-model="c.groupsAndTopics" readonly="true">
+			<md-chip-template>
+				<kusema-inline-group ng-if="$chip.unitCode" group="$chip"></kusema-inline-group>
+				<ng-if ng-if="!$chip.unitCode">{{$chip.name}}</ng-if>
+			</md-chip-template>
+		</md-chips>
+		<!-- what should work:
+			<md-chips>
+				<md-chip class="groupChip">{{c.question.group.unitCode}}</md-chip>
+				<md-chip class="topicChip" ng-repeat="topic in c.question.topics">{{topic.name}}</md-chip>
+			</md-chips>
+		-->
 	</md-card-content>
 	<div class="md-actions" layout="row" layout-align="end center">
 		<md-button ui-sref="user.question({id: c.question._id})">Answer</md-button>

--- a/Client/common/models.js
+++ b/Client/common/models.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var BaseContent = function BaseContent(contentJSON, factory) {
+var BaseJson = function BaseJson(contentJSON, factory) {
         Object.defineProperty(this, 'factory', {writable:true, value:null, enumerable: false});
         this.factory = factory;
         for (var property in Object.getPrototypeOf(this)) {
@@ -9,19 +9,31 @@ var BaseContent = function BaseContent(contentJSON, factory) {
                 this[property] = contentJSON[property];
             }
         }
+        this.json = contentJSON;
         this.dateCreated = new Date(this.dateCreated);
         this.dateModified = new Date(this.dateModified);
+    }
+
+    BaseJson.prototype = Object.create(Object.prototype, {
+        constructor: {writable: false, value: BaseJson, enumerable: false},
+        json: {writable: true, value: 'BaseContent', enumerable: false},
+        _id: {writable: true, value: 0, enumerable: true},
+        dateCreated: { writable: true, value: null, enumerable: true },
+        dateModified: { writable: true, value: null, enumerable: true },
+    })
+//} BaseJson
+
+
+var BaseContent = function BaseContent(contentJSON, factory) {
+        BaseJson.call(this, contentJSON, factory);
     	return this;
     }
-    BaseContent.prototype = Object.create(Object.prototype, {
+    BaseContent.prototype = Object.create(BaseJson.prototype, {
         name: {writable: false, value: 'BaseContent', enumerable: false},
         constructor: {writable: false, value: BaseContent, enumerable: false},
-        _id: {writable: true, value: 0, enumerable: true},
         author: { writable: true, value: 0, enumerable: true }, //TODO add object ID requirement here
         authorName: { writable: true, value: "", enumerable: true},
         message: { writable: true, value: 0, enumerable: true },
-        dateCreated: { writable: true, value: null, enumerable: true },
-        dateModified: { writable: true, value: null, enumerable: true },
         comments: { writable: true, value: [], enumerable: true},
         upVotes: { writable: true, value: 0, enumerable: true },
         downVotes: { writable: true, value: 0, enumerable: true},
@@ -87,6 +99,9 @@ var Answer = function Answer(answerJSON, answerFactory) {
 //} Answer
 
 
+
+
+kusema.models.BaseJson = BaseJson;
 kusema.models.BaseContent = BaseContent;
 kusema.models.Comment = Comment;
 kusema.models.Question = Question;

--- a/Client/common/models.js
+++ b/Client/common/models.js
@@ -68,13 +68,23 @@ var Question = function Question(questionJSON, questionService) {
         if (this.answers) {
             this.answers = questionService.answerService.createClientModels(this.answers);
         };
+        questionService.groupService.waitForGroups.then(function() {
+            if (this.group) {
+                this.group = questionService.groupService.getGroup(this.group);
+            }
+            if (this.topics) {
+                this.topics = questionService.groupService.topicService.getTopics(this.topics);
+            }
+        }.bind(this));
         return this;
     }
     Question.prototype = Object.create(BaseContent.prototype, {
         name: {writable: false, value: 'Question', enumerable: false},
         constructor: {writable: false, value: Question, enumerable: false},
         title: { writable: true, value: "", enumerable: true },
-        answers: {writable: true, value: null, enumerable: true}
+        answers: {writable: true, value: null, enumerable: true},
+        group: {writable: true, value: null, enumerable: true},
+        topics: {writable: true, value: null, enumerable: true}
     });
 //} Question
 
@@ -99,6 +109,25 @@ var Answer = function Answer(answerJSON, answerFactory) {
 //} Answer
 
 
+var Group = function Group(groupJSON, groupService) {
+        BaseJson.call(this, groupJSON, groupService);
+        if (this.topics) {
+            this.topics = this.topics.map(function(topicID) { return groupService.topicService.getTopic(topicID); });
+        }
+    }
+    Group.prototype = Object.create(BaseJson.prototype, {
+        name: {writable: true, value: '', enumerable: true},
+        topics: {writable: true, value: null, enumerable: true},
+        unitCode: {writable: true, value: '', enumerable: true},
+        title: {writable: true, value: '', enumerable: true}
+    });
+
+var Topic = function Topic(topicJSON) {
+        BaseJson.call(this, topicJSON);
+    }
+    Topic.prototype = Object.create(BaseJson.prototype, {
+        name: {writable: true, value: '', enumerable: true},
+    });
 
 
 kusema.models.BaseJson = BaseJson;
@@ -106,3 +135,5 @@ kusema.models.BaseContent = BaseContent;
 kusema.models.Comment = Comment;
 kusema.models.Question = Question;
 kusema.models.Answer = Answer;
+kusema.models.Group = Group;
+kusema.models.Topic = Topic;

--- a/Client/common/models.js
+++ b/Client/common/models.js
@@ -55,7 +55,7 @@ var BaseContent = function BaseContent(contentJSON, factory) {
     BaseContent.prototype.update = function(newJson) {
         return this.factory.update(this._id, newJson)
                 .then(function(updated) {
-                    this.constructor.call(this, newJson, this.factory);
+                    this.constructor.call(this, updated, this.factory);
                     return this;
                 }.bind(this));  
     };

--- a/Client/common/services/AnswerService.js
+++ b/Client/common/services/AnswerService.js
@@ -2,7 +2,7 @@
 
 var AnswerService = function($http, kusemaConfig, socketFactory) {
 		this.initCommonDeps($http, kusemaConfig, socketFactory);
-		this.urlBase = kusemaConfig.url()+'api/answers';
+		this.urlBase = 'api/answers';
 	}
 
 	AnswerService.prototype = Object.create(BaseContentService.prototype ,{

--- a/Client/common/services/BaseContentService.js
+++ b/Client/common/services/BaseContentService.js
@@ -58,7 +58,8 @@ var BaseContentService = function($http, kusemaConfig, socketFactory, questionSe
         		   .then(this.modelFromResponse.bind(this));
     };
     BaseContentService.prototype.update = function (id, editedContent) {
-        return this.$http.put(this.urlBase + '/' + id, editedContent);
+        return this.$http.put(this.urlBase + '/' + id, JSON.stringify(editedContent, this.sanitizeJson))
+        		   .then(function(response) {return response.data});
     };
     BaseContentService.prototype.upVote = function (id) {
     	return this.$http.put(this.urlBase + '/upvote/' + id);

--- a/Client/common/services/BaseContentService.js
+++ b/Client/common/services/BaseContentService.js
@@ -7,13 +7,12 @@ var BaseContentService = function($http, kusemaConfig, socketFactory, questionSe
 		this.commentService = commentService;
 	}
 
-	BaseContentService.prototype = Object.create(Object.prototype, {
+	BaseContentService.prototype = Object.create(BaseJsonService.prototype, {
 		model: {writable: false, enumerable: false, value: BaseContent}
 	});
 
 	BaseContentService.prototype.initCommonDeps = function($http, kusemaConfig, socketFactory) {
-		this.$http = $http;
-		this.kusemaConfig = kusemaConfig
+        BaseJsonService.prototype.initCommonDeps.call(this, $http, kusemaConfig);
 		this.socketFactory = socketFactory;
 	}
 
@@ -47,22 +46,6 @@ var BaseContentService = function($http, kusemaConfig, socketFactory, questionSe
 				break;
 		}
 	}
-    BaseContentService.prototype.createClientModel = function(responseJSON) {
-        return new this.model(responseJSON, this);
-    }
-	BaseContentService.prototype.modelFromResponse = function(response) {
-		return this.createClientModel(response.data);
-	}
-    BaseContentService.prototype.getAll = function () {
-        return this.$http.get(this.urlBase)
-        		   .then(function(response) {
-        		   		return response.data.map(this.createClientModel.bind(this));
-        		   }.bind(this));
-    };
-    BaseContentService.prototype.get = function (id) {
-        return this.$http.get(this.urlBase + '/' + id)
-        		   .then(this.modelFromResponse.bind(this));
-    };
     BaseContentService.prototype.add = function (content, extraURL) {
     	var content;
     	if (!extraURL) {
@@ -86,22 +69,6 @@ var BaseContentService = function($http, kusemaConfig, socketFactory, questionSe
     BaseContentService.prototype.delete = function (id) {
         return this.$http.delete(this.urlBase + '/' + id);
     };
-    BaseContentService.prototype.createClientModels = function(responseJSON) {
-        return responseJSON.map(this.createClientModel.bind(this));
-    }
-    // this gets passed as a parameter to JSON.stringify; its function is to replace
-    // any submodels in our main model with just their _ids.
-    BaseContentService.prototype.sanitizeJson = function(key, value) {
-    	if (value === this) {
-    		// we always want to continue to recurse into our main object, else
-    		// it'll get caught in the next bit and truncated to just its ID!
-    		return value;
-    	} else if (value && value._id) {
-    		return value._id;
-    	} else {
-    		return value;
-    	}
-    }
 //} BaseContentService
 
-kusema.service('baseContentService', ['$http', 'kusemaConfig', 'socketFactory', 'questionService', 'answerService', 'commentService', BaseContentService]);
+kusema.service('baseContentService', ['$http', 'kusemaConfig', 'socketFactory', 'questionService', 'answerService', 'commentService', 'baseJsonService', BaseContentService]);

--- a/Client/common/services/BaseJsonService.js
+++ b/Client/common/services/BaseJsonService.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var BaseJsonService = function($http, kusemaConfig) {
+		this.initCommonDeps($http, kusemaConfig);
+		this.serverURL = kusemaConfig.url();
+		return this;
+	}
+
+	BaseJsonService.prototype = Object.create(Object.prototype, {
+		serverURL: {writable: true, enumerable: false, value: ''},
+		_urlStem: {writable: true, enumerable: false, value: ''},
+		urlBase: {
+			get: function() {
+				return this.serverURL+this._urlStem
+			},
+			set: function(urlStem) {
+				this._urlStem = urlStem;
+			}
+		},
+		model: {writable: false, enumerable: false, value: BaseJson}
+	});
+
+	BaseJsonService.prototype.initCommonDeps = function($http, kusemaConfig) {
+			this.$http = $http;
+			this.kusemaConfig = kusemaConfig
+	}
+	BaseJsonService.prototype.createClientModel = function(responseJSON) {
+	    return new this.model(responseJSON, this);
+	}
+	BaseJsonService.prototype.modelFromResponse = function(response) {
+		return this.createClientModel(response.data);
+	}
+    BaseJsonService.prototype.get = function (id) {
+        return this.$http.get(this.urlBase + '/' + id)
+        		   .then(this.modelFromResponse.bind(this));
+    };
+    BaseJsonService.prototype.createClientModels = function(responseJSON) {
+        return responseJSON.map(this.createClientModel.bind(this));
+    }
+    // this gets passed as a parameter to JSON.stringify; its function is to replace
+    // any submodels in our main model with just their _ids.
+    BaseJsonService.prototype.sanitizeJson = function(key, value) {
+    	if (key === '') {
+    		// we always want to continue to recurse into our main object, else
+    		// it'll get caught in the next bit and truncated to just its ID!
+    		return value;
+    	} else if (value && value._id) {
+    		return value._id;
+    	} else {
+    		return value;
+    	}
+    }
+    BaseJsonService.prototype.getAll = function () {
+        return this.$http.get(this.urlBase)
+        		   .then(function(response) {
+        		   		return response.data.map(this.createClientModel.bind(this));
+        		   }.bind(this));
+    };
+
+kusema.service('baseJsonService', ['$http', 'kusemaConfig', BaseJsonService]);

--- a/Client/common/services/CommentService.js
+++ b/Client/common/services/CommentService.js
@@ -24,7 +24,7 @@ var CommentSubscription = function(socketFactory, commentFactory, baseContent, c
 
 var CommentService = function($http, kusemaConfig, socketFactory) {
 		this.initCommonDeps($http, kusemaConfig, socketFactory);
-        this.urlBase = kusemaConfig.url()+'api/comments';
+        this.urlBase = 'api/comments';
     }
 
 	CommentService.prototype = Object.create(BaseContentService.prototype, {

--- a/Client/common/services/GroupService.js
+++ b/Client/common/services/GroupService.js
@@ -1,0 +1,41 @@
+var GroupService = function($rootScope, $http, topicService, kusemaConfig) {
+		this.initCommonDeps($http, kusemaConfig);
+		this.topicService = topicService;
+		this.rootScope = $rootScope;
+		this.urlBase = 'api/groups'
+		this.bindables = {
+			groups: null,
+			groupsArray: null // there are some places where we need to lookup by key, and others where we need an array :(
+		}
+		this._wait = {};
+		this.waitForGroups = new Promise(function(resolve, reject) {
+			this._wait.resolve = resolve;
+			this._wait.reject = reject;
+		}.bind(this));
+		this.getAll();
+	}
+
+	GroupService.prototype = Object.create(BaseJsonService.prototype, {
+		'model': {writable: false, enumerable: false, value: Group}
+	});
+
+	GroupService.prototype.getAll = function() {
+		return BaseJsonService.prototype.getAll.call(this)
+		.then(this.topicService.waitForTopics)
+		.then(function(groups) {
+			this.bindables.groups = {};
+			this.bindables.groupsArray = [];
+			for (var group of groups) {
+				this.bindables.groups[group._id] = group;
+				this.bindables.groupsArray.push(group);
+			}
+			this._wait.resolve();
+			return this.bindables.groups;
+		}.bind(this));
+	}
+
+	GroupService.prototype.getGroup = function(groupID) {
+		return this.bindables.groups[groupID];
+	}
+
+kusema.service('groupService', ['$rootScope', '$http', 'topicService', 'kusemaConfig', GroupService]);

--- a/Client/common/services/LoginService.js
+++ b/Client/common/services/LoginService.js
@@ -48,15 +48,15 @@ var LoginService = function($http, $rootScope, kusemaConfig) {
 		return this.$http.post(
 							this.kusemaConfig.url()+'account/login_local',
 							{'username': username, 'password': password}
-						).then(
-						function(response) {
+						)
+						.then( function(response) {
 							console.log('login request done');
 							return this.checkLogin();
-						}.bind(this),
-						function(error) {
+						}.bind(this))
+						.catch( function(error) {
+							this.loginState = 0;
 							console.log('login error');
-						}
-					);
+						}.bind(this));
 	};
 	LoginService.prototype.logout = function() {
 		var logoutRequest = this.$http.post(this.kusemaConfig.url()+'account/logout');

--- a/Client/common/services/QuestionService.js
+++ b/Client/common/services/QuestionService.js
@@ -11,11 +11,12 @@ var QuestionService = function($http, kusemaConfig, socketFactory, answerService
 		model: {writable: false, enumerable: false, value: Question}
 	});
 
-	QuestionService.prototype.getNextTenQuestions = function (requestNumber) {
-	        return this.$http.get(this.urlBase + '/tenMore/' + requestNumber)
-	                    .then(function(response) {
-	                        return this.createClientModels(response.data);
-	                    }.bind(this));
+	QuestionService.prototype.getNextTenQuestions = function (requestNumber, group) {
+		var groupURL = (group) ? ('/'+group) : '';
+        return this.$http.get(this.urlBase + '/tenMore' + groupURL + '/' + requestNumber)
+                    .then(function(response) {
+                        return this.createClientModels(response.data);
+                    }.bind(this));
 	    };
 	    
 

--- a/Client/common/services/QuestionService.js
+++ b/Client/common/services/QuestionService.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var QuestionService = function($http, kusemaConfig, socketFactory, answerService) {
+var QuestionService = function($http, kusemaConfig, socketFactory, answerService, groupService) {
 		this.initCommonDeps($http, kusemaConfig, socketFactory);
 		this.urlBase = this.kusemaConfig.url()+'api/questions';
 		this.answerService = answerService;
+		this.groupService = groupService;
 	}
 
 	QuestionService.prototype = Object.create(BaseContentService.prototype, {
@@ -19,4 +20,4 @@ var QuestionService = function($http, kusemaConfig, socketFactory, answerService
 	    
 
 
-kusema.service('questionService', ['$http', 'kusemaConfig', 'socketFactory', 'answerService', QuestionService]);
+kusema.service('questionService', ['$http', 'kusemaConfig', 'socketFactory', 'answerService', 'groupService', QuestionService]);

--- a/Client/common/services/QuestionService.js
+++ b/Client/common/services/QuestionService.js
@@ -2,7 +2,7 @@
 
 var QuestionService = function($http, kusemaConfig, socketFactory, answerService, groupService) {
 		this.initCommonDeps($http, kusemaConfig, socketFactory);
-		this.urlBase = this.kusemaConfig.url()+'api/questions';
+		this.urlBase = 'api/questions';
 		this.answerService = answerService;
 		this.groupService = groupService;
 	}

--- a/Client/common/services/TopicService.js
+++ b/Client/common/services/TopicService.js
@@ -1,0 +1,41 @@
+var TopicService = function($http, kusemaConfig) {
+		this.initCommonDeps($http, kusemaConfig);
+		this.urlBase = 'api/topics'
+		this.bindables = {
+			topics: null,
+		}
+		this._wait = {};
+		this.waitForTopics = new Promise(function(resolve, reject) {
+			this._wait.resolve = resolve;
+			this._wait.reject = reject;
+		}.bind(this));
+		this.getAll();
+	}
+
+	TopicService.prototype = Object.create(BaseJsonService.prototype, {
+		'model': {writable: false, enumerable: false, value: Topic}
+	});
+
+	TopicService.prototype.getAll = function() {
+		BaseJsonService.prototype.getAll.call(this)
+		.then(function(topics) {
+			this.bindables.topics = {};
+			this.bindables.topicsArray = [];
+			for (var topic of topics) {
+				this.bindables.topics[topic._id] = topic;
+				this.bindables.topicsArray.push(topic);
+			}
+			this._wait.resolve();
+			return this.bindables.topics;
+		}.bind(this));
+	}
+
+	TopicService.prototype.getTopic = function(topicID) {
+		return this.bindables.topics[topicID];
+	}
+
+	TopicService.prototype.getTopics = function(topicIDs) {
+		return topicIDs.map(this.getTopic.bind(this));
+	}
+
+kusema.service('topicService', ['$http', 'kusemaConfig', TopicService]);

--- a/Client/index.html
+++ b/Client/index.html
@@ -68,6 +68,7 @@
     <script src="common/components/QuestionPreview/questionPreview.js"></script>
     <script src="common/components/ContentCard/contentCard.js"></script>
     <script src="common/components/InlineDate/inlineDate.js"></script>
+    <script src="common/components/InlineGroup/inlineGroup.js"></script>
     <script src="common/components/Markdown/markdown.js"></script>
 
 

--- a/Client/index.html
+++ b/Client/index.html
@@ -37,6 +37,8 @@
 
     <script src="common/models.js"></script>
 
+    <script src="common/services/BaseJsonService.js"></script>
+
     <script src="common/services/BaseContentService.js"></script>
     <script src="common/services/QuestionService.js"></script>
     <script src="common/services/AnswerService.js"></script>

--- a/Client/index.html
+++ b/Client/index.html
@@ -21,7 +21,6 @@
     <md-content id="content" style="position: fixed; width: 100%; height: 100%" ui-view></md-content>
 
     <script src="bower_components/angular/angular.js"></script>
-    <script src="bower_components/json3/lib/json3.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>
     <script src="bower_components/angular-animate/angular-animate.min.js"></script>
     <script src="bower_components/socket.io-client/socket.io.js"></script>

--- a/Client/index.html
+++ b/Client/index.html
@@ -43,6 +43,10 @@
     <script src="common/services/QuestionService.js"></script>
     <script src="common/services/AnswerService.js"></script>
     <script src="common/services/CommentService.js"></script>
+
+    <script src="common/services/TopicService.js"></script>
+    <script src="common/services/GroupService.js"></script>
+
     <script src="common/services/LoginService.js"></script>
     <script src="common/services/SocketService.js"></script>
     <script src="common/services/MarkdownService.js"></script>

--- a/Client/styles/common.css
+++ b/Client/styles/common.css
@@ -11,3 +11,7 @@
 .usernameFloat:after {
 	content: ':\a0';
 }
+
+.unitCode {
+	font-variant: small-caps;
+}

--- a/Client/user/kusemaUser.js
+++ b/Client/user/kusemaUser.js
@@ -23,11 +23,14 @@ var KusemaUserDirective = function() {
 	};
 };
 
-var KusemaUserController = function($scope, $mdSidenav) {
+var KusemaUserController = function($scope, $mdSidenav, groupService) {
 	console.log('yo')
 	this.$mdSidenav = $mdSidenav;
 	$scope.toggle = this.toggle.bind(this);
-	return this;
+	$scope.groupServiceData = groupService.bindables;
+	$scope.searchGroups = function() {
+		return $scope.groupServiceData.groupsArray;
+	}
 }
 KusemaUserController.prototype = Object.create(Object.prototype);
 
@@ -36,7 +39,8 @@ KusemaUserController.prototype.toggle = function(id) {
 	this.$mdSidenav(id).toggle();
 }
 
+
 kusema.addModule('kusema.user', ['ngMaterial'])
 	   .config(KusemaUserConfig)
 	   .directive('kusemaUser', KusemaUserDirective)
-	   .controller('kusemaUserController', ['$scope', '$mdSidenav', KusemaUserController]);
+	   .controller('kusemaUserController', ['$scope', '$mdSidenav', 'groupService', KusemaUserController]);

--- a/Client/user/kusemaUser.js
+++ b/Client/user/kusemaUser.js
@@ -4,6 +4,10 @@ var KusemaUserConfig = function($stateProvider) {
 		    url: '',
 		    template: '<kusema-question-list></kusema-question-list>'
 		})
+		.state('user.group', {
+		    url: '/group/:groupID',
+		    template: '<kusema-question-list group="$root.$stateParams.groupID"></kusema-question-list>'
+		})
 		.state('user.question', {
 			url: '/question/:id',
 			template: '<kusema-question-full></kusema-question-full>'

--- a/Client/user/kusemaUserTemplate.html
+++ b/Client/user/kusemaUserTemplate.html
@@ -20,13 +20,9 @@
     <h2 class="md-subhead">Groups</h2>
     <md-content>
     <ul style="list-style-type: none; padding: 0;">
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">ENG1003</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Monash Stalker Space</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Chem Questions</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Monash Hikers</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Monash Stalker Space</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Chem Questions</a></li>
-    <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="#/group/eng1002">Monash Hikers</a></li>
+    <li ng-repeat="group in groupServiceData.groups">
+      <a href="group/{{group.code}}" ng-bind="group.name"></a>
+    </li>
     <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="">+ Make a group</a></li>
     </ul>
     </md-content>

--- a/Client/user/kusemaUserTemplate.html
+++ b/Client/user/kusemaUserTemplate.html
@@ -20,8 +20,8 @@
     <h2 class="md-subhead">Groups</h2>
     <md-content>
     <ul style="list-style-type: none; padding: 0;">
-    <li ng-repeat="group in groupServiceData.groups">
-      <a href="group/{{group.code}}" ng-bind="group.name"></a>
+    <li ng-repeat="group in groupServiceData.userGroups">
+      <a ui-sref="user.group({groupID: group._id})" ng-bind="group.name"></a>
     </li>
     <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="">+ Make a group</a></li>
     </ul>

--- a/Client/user/questionList/questionList.js
+++ b/Client/user/questionList/questionList.js
@@ -28,7 +28,8 @@
 
 var QuestionListDirective = function() {
 	return {
-		scope: {
+		scope: {},
+		bindToController: {
 			'group': '='
 		},
 		templateUrl: 'user/questionList/questionListTemplate.html',
@@ -68,7 +69,7 @@ var QuestionListController = function(questionFactory, $mdDialog, $scope) {
 	      }
 	    };
 
-	    questionFactory.getNextTenQuestions(0)
+	    questionFactory.getNextTenQuestions(0, this.group)
 	    .then(
 	        function (quest) {
 	            this.questions.addQuestions(quest);

--- a/Client/user/questionList/questionListTemplate.html
+++ b/Client/user/questionList/questionListTemplate.html
@@ -3,12 +3,13 @@
 
 </md-content>
 
-<md-button class="md-fab" aria-label="Ask a Question" style="position: fixed; bottom: 20px; right: 20px;" ng-click="c.showWriter()">
+<md-button class="md-fab" aria-label="Ask a Question" style="position: fixed; bottom: 20px; right: 20px;" ng-click="c.showWriter($event)">
   <md-icon md-font-set="material-icons">add</md-icon>
 </md-button>
 
 <template id="addQuestionDialog">
-<md-dialog><md-dialog-content>
+<md-dialog
+	md-focus-on-open="false"><md-dialog-content>
 <kusema-edit-content-form
 	on-cancel="c.hideWriter()"
 	on-submit="c.newQuestionPosted(newContent)"

--- a/Server/config/groups.js
+++ b/Server/config/groups.js
@@ -1,0 +1,158 @@
+'use strict';
+
+var Topic = require('../models/topic.js');
+var Group = require('../models/group.js');
+
+var mongoose = require('mongoose');
+
+//written in shorthand as we will be writing this by hand for the near-to-medium future.
+//n: name, p: [list of parents], s: short name
+var topics = [
+	{n:'Information Technology', s:'IT'},
+	{n:'Computer Science', p:['Information Technology']},
+	{n:'Programming', p:['Information Technology']},
+	{n:'Introductory Programming', p:['Programming']},
+	{n:'MATLAB', p:['Programming']},
+	{n:'Software Engineering', p:['Information Technology']},
+	{n:'Software Testing', p:['Software Engineering']},
+	{n:'Software Documentation', p:['Software Engineering']},
+	{n:'Object-Oriented Programming', p:['Programming']},
+	{n:'Javascript', p:['Programming']},
+
+	{n:'Mathematics'},
+	{n:'Algebra'},
+	{n:'Linear Algebra',p:['Algebra']},
+	{n:'Computational Mathematics', p:['Mathematics', 'Computer Science']},
+	{n:'Optimization',p:['Computational Mathematics']},
+	{n:'Curve Fitting', p:['Computational Mathematics', 'Statistics']},
+	{n:'Numerical Calculus', p:['Computational Mathematics']},
+	{n:'Differential Equations', p:['Mathematics']},
+	{n:'Ordinary Differential Equations', s:'ODEs', p:['Differential Equations']},
+	{n:'Geometry', p:['Mathematics']},
+	{n:'Calculus', p:['Mathematics']},
+	{n:'Multivariable Calculus', p:['Calculus']},
+	{n:'Sequences', p:['Mathematics', 'Series']},
+	{n:'Series', p:['Calculus']},
+
+
+	{n:'Physics'},
+	{n:'Kinetics', p:['Physics']},
+
+	{n:'Chemistry'},
+	{n:'Materials Science', p:['Chemistry']},
+	{n:'Microstructure', p:['Materials Science']},
+
+	{n:'Materials Engineering'},
+	{n:'Material Processing', p:['Materials Engineering']},
+
+	{n:'Mechanical Engineering'},
+
+	{n:'Civil Engineering'},
+	{n:'Structures', p:['Civil Engineering', 'Physics']},
+
+	{n:'Engineering Profession'},
+
+	{n:'Electrical Engineering'},
+	{n:'Circuits', p:['Electrical Engineering']},
+	{n:'Digital Circuits', p:['Circuits', 'Computer Science']},
+
+	{n:'Chemical Engineering'},
+	{n:'Mass Balances', p:['Chemical Engineering']},
+	{n:'Thermodynamics', p:['Chemical Engineering', 'Mechanical Engineering', 'Physics']},
+];
+
+var units = [
+	{c:'eng1060',n:'Computing for Engineers',t:[
+		'Introductory Programming',
+		'MATLAB',
+		'Linear Algebra',
+		'Computational Mathematics',
+		'Optimization',
+		'Curve Fitting',
+		'Numerical Calculus',
+	]},
+	{c:'eng1091',n:'Mathematics for Engineering', t:[
+		'Linear Algebra',
+		'Sequences',
+		'Series',
+		'Calculus',
+		'Multivariable Calculus',
+		'Ordinary Differential Equations',
+	]},
+	{c:'eng1001',n:'Engineering Design: Lighter, Faster Stronger', t:[
+		'Civil Engineering',
+		'Structures',
+		'Kinetics',
+		'Materials Engineering',
+		'Microstructure',
+		'Material Processing',
+		'Engineering Profession'
+	]},
+	{c:'eng1002',n:'Engineering Design: Cleaner, Safer, Smarter', t:[
+		'Electrical Engineering',
+		'Circuits',
+		'Digital Circuits',
+		'Chemical Engineering',
+		'Mass Balances',
+		'Thermodynamics',
+		'Materials Engineering',
+		'Material Processing',
+		'Engineering Profession'
+	]},
+	{c:'eng1003',n:'Engineering Mobile Apps', t:[
+		'Software Engineering',
+		'Software Testing',
+		'Software Documentation',
+		'Javascript'
+	]}
+];
+
+var dbReadyPromise = new Promise(function(resolve, reject) {
+	var i = 0;
+	var maybeDone = function (error, result) {
+		console.log('dropped');
+		i++;
+		if (i >= 2) {
+			resolve();
+		}
+	}
+	mongoose.connection.on('open', function() {
+		mongoose.connection.db.dropCollection('topics', maybeDone),
+		mongoose.connection.db.dropCollection('groups', maybeDone)
+	});
+}).then( function() { return Promise.all(
+	topics.map( function(topicShorthand) {
+		var topic = new Topic();
+		topic.name = topicShorthand.n;
+		return topic.save();
+	})
+)}).then( function() { return Promise.all(
+	units.map( function(unitShorthand) {
+		var unit = new Group({}, false);
+		unit.name = unitShorthand.c + ': '+ unitShorthand.n;
+		unit.unitCode = unitShorthand.c;
+		unit.title = unitShorthand.n;
+		return Topic.find({'name': {'$in': unitShorthand.t}})
+	  	.then(function(topics) {
+			unit.topics = topics.map(function(topic) { return topic._id } );
+			unit.embeddedTopics = topics;
+			return unit;
+		}).then(function(unit) {
+			return unit.save();
+		})
+		.then(
+			function(saved) {
+				console.log('yay');
+			},
+			function(error) {
+				console.log('saving error');
+				console.log(error);
+			}
+		);
+	})
+)}, function(error) {
+	console.error('error');
+	console.error(error);
+});
+
+

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -14,7 +14,6 @@ exp.findByQuestionId = function(req, res, next) {
 };
 
 exp.addByQuestionId = function(req, res, next) {
-
     var answer = new Answer();
     
     answer.author       = new ObjectId(req.user._id);
@@ -23,32 +22,22 @@ exp.addByQuestionId = function(req, res, next) {
     answer.question     = new ObjectId(req.params.questionId);
     answer.upVotes.     push(req.user._id);
 
-    answer.save()
+    return answer.save()
     .then( function(answer) {
-            // if we want out plugins to run, i.e. autopopulation, then we need to run a database find :(
-            Answer.findById(answer._id).then(res.mjson.bind(res));
-    })
-    .catch( function (error) {
-            next(error);
+            // if we want our plugins to run, i.e. autopopulation, then we need to run a database find :(
+            return Answer.findById(answer._id)
     });
-};
+}
 
 exp.deleteAnswer = function(req, res, next) {
-  
     // TODO add auth info ensure only creator, mods and admin can delete
-    Answer.setAsDeleted(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Answer.setAsDeleted(req.params.answerId, req.user._id);
 };
 
 exp.upVoteAnswer = function(req, res, next) {
-    Answer.upVote(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Answer.upVote(req.params.answerId, req.user._id);
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-    Answer.downVote(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    Answer.downVote(req.params.answerId, req.user._id);
 };

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -4,12 +4,9 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findByQuestionId = function(req, res, next) {
-    Question.findById(req.params.questionId)
+    return Question.findById(req.params.questionId)
     .then( function(question) {
-        res.json(question.answers);
-    })
-    .catch( function(error) {
-        next(error);
+        return question.answers;
     });
 };
 
@@ -39,5 +36,5 @@ exp.upVoteAnswer = function(req, res, next) {
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-    Answer.downVote(req.params.answerId, req.user._id);
+    return Answer.downVote(req.params.answerId, req.user._id);
 };

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -5,14 +5,12 @@ var exp = module.exports;
 
 exp.findByQuestionId = function(req, res, next) {
     Question.findById(req.params.questionId)
-    .then(
-        function(question) {
-            res.json(question.answers);
-        },
-        function(error) {
-            next(error);
-        }
-    );
+    .then( function(question) {
+        res.json(question.answers);
+    })
+    .catch( function(error) {
+        next(error);
+    });
 };
 
 exp.addByQuestionId = function(req, res, next) {
@@ -22,45 +20,35 @@ exp.addByQuestionId = function(req, res, next) {
     answer.author       = new ObjectId(req.user._id);
     answer.anonymous    = req.body.anonymous;
     answer.message      = req.body.message;
-    answer.question   = new ObjectId(req.params.questionId);
+    answer.question     = new ObjectId(req.params.questionId);
     answer.upVotes.     push(req.user._id);
 
-    answer.save().then(
-        function(answer) {
+    answer.save()
+    .then( function(answer) {
             // if we want out plugins to run, i.e. autopopulation, then we need to run a database find :(
             Answer.findById(answer._id).then(res.mjson.bind(res));
-        },
-        function (error) {
+    })
+    .catch( function (error) {
             next(error);
-        });
+    });
 };
 
 exp.deleteAnswer = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-
-    Answer.setAsDeleted(req.params.answerId, req.user._id).then(
-        res.json,
-        next
-    );
+    Answer.setAsDeleted(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.upVoteAnswer = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.json(upVoted);
-    }
-
-    Answer.upVote(req.params.answerId, req.user._id, done)
+    Answer.upVote(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.json(downVoted);
-    }
-
-    Answer.downVote(req.params.answerId, req.user._id, done)
+    Answer.downVote(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -17,75 +17,56 @@ exp.findByQAId = function(req, res, next) {
 		findQuery.push({underscoreProperty: valueToPush});
 	});
 
-	var getComments = Comment.find({$and: findQuery}).exec();
-
-	getComments.addBack(function (err, comments) {
-		if (err) return next(err);
-		res.json(comments);
-	})
+	Comment.find({$and: findQuery})
+	.then( res.json )
+	.catch( next );
 };
 
 exp.addByQAId = function(req, res, next) {
 	var comment = new Comment();
 
-	comment.author = req.user._id;
+	comment.author  = req.user._id;
 	comment.message = req.body.message;
-	comment.parent = new ObjectId(req.params.parentId);
+	comment.parent  = new ObjectId(req.params.parentId);
 
-	comment.save( function (err, comment) {
-		if (err) return next(err);
-		res.json(comment)
-	});
+	comment.save()
+	.then( res.json )
+	.catch ( next );
 };
 
 exp.findByCommentId = function(req, res, next) {
-	var getComment = Comment.findById(req.params.commentId).exec();
-	getComment.addBack(function (err, comment) {
-		if (err) return next(err);
-		res.json(comment);
-	});
+	Comment.findById(req.params.commentId)
+	.then( res.json )
+	.catch( next );
 }
 
 exp.updateComment = function(req, res, next) {
-	Comment.findById(req.params.commentId).then(
-		function(comment) {
-			comment.message = req.body.message;
-			return comment.save();
-		}).then(
-		function(savedComment) {
-			res.json(savedComment);
-		},
-		function(error) {
-			return next(error);
-		});
+	Comment.findById(req.params.commentId)
+	.then( function(comment) {
+		comment.message = req.body.message;
+		return comment.save();
+	})
+	.then( res.json )
+	.catch( next );
 }
 
 exp.deleteComment = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
 
-    Comment.setAsDeleted(req.params.commentId, req.user._id).then(
-    	res.mjson,
-    	next
-    );
+    Comment.setAsDeleted(req.params.commentId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.upVoteComment = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.json(upVoted);
-    }
-
-    Comment.upVote(req.params.commentId, req.user._id, done)
+    Comment.upVote(req.params.commentId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.downVoteComment = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.json(downVoted);
-    }
-
-    Comment.downVote(req.params.commentId, req.user._id, done)
+    Comment.downVote(req.params.commentId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -7,6 +7,7 @@ var exp = module.exports;
 
 exp.findByQAId = function(req, res, next) {
 	findQuery = [];
+	//I wholeheartedly apologize for the following godawful mess and will fix soon :)
 	propertiesToFind ['questionId', 'answerId'];
 	propertiesToFind.foreach(function(property) {
 		var valueToPush;
@@ -17,9 +18,7 @@ exp.findByQAId = function(req, res, next) {
 		findQuery.push({underscoreProperty: valueToPush});
 	});
 
-	Comment.find({$and: findQuery})
-	.then( res.json )
-	.catch( next );
+	return Comment.find({$and: findQuery});
 };
 
 exp.addByQAId = function(req, res, next) {
@@ -29,44 +28,32 @@ exp.addByQAId = function(req, res, next) {
 	comment.message = req.body.message;
 	comment.parent  = new ObjectId(req.params.parentId);
 
-	comment.save()
-	.then( res.json )
-	.catch ( next );
+	return comment.save();
 };
 
 exp.findByCommentId = function(req, res, next) {
-	Comment.findById(req.params.commentId)
-	.then( res.json )
-	.catch( next );
+	return Comment.findById(req.params.commentId)
 }
 
 exp.updateComment = function(req, res, next) {
-	Comment.findById(req.params.commentId)
+	return Comment.findById(req.params.commentId)
 	.then( function(comment) {
 		comment.message = req.body.message;
 		return comment.save();
 	})
-	.then( res.json )
-	.catch( next );
 }
 
 exp.deleteComment = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
 
-    Comment.setAsDeleted(req.params.commentId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Comment.setAsDeleted(req.params.commentId, req.user._id)
 };
 
 exp.upVoteComment = function(req, res, next) {
-    Comment.upVote(req.params.commentId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Comment.upVote(req.params.commentId, req.user._id);
 };
 
 exp.downVoteComment = function(req, res, next) {
-    Comment.downVote(req.params.commentId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Comment.downVote(req.params.commentId, req.user._id);
 };

--- a/Server/controllers/groups.js
+++ b/Server/controllers/groups.js
@@ -20,12 +20,13 @@ exp.findById = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  var getGroups = Group.find().exec();
-
-  getGroups.addBack( function (err, groups) {
-    if (err) return next(err);
-    res.json(groups);
+  Group.find()
+  .then(function(groups) {
+    res.mjson(groups);
   })
+  .catch(function(error) {
+    next(error);
+  });
 
 };
 

--- a/Server/controllers/groups.js
+++ b/Server/controllers/groups.js
@@ -5,31 +5,16 @@ var exp = module.exports;
 
 
 exp.findById = function (req, res, next) {
-
-  var getGroup = Group.findOne(
-    { '_id': new ObjectId(req.params.groupId) }
-  ).exec();
-
-  getGroup.addBack( function (err, group) {
-    if (err) return next(err);
-    res.json(group);
-  });
-
+  Group.findById(req.params.groupId)
+  .then( res.json )
+  .catch( next );
 };
-
 
 exp.findAll = function (req, res, next) {
-
   Group.find()
-  .then(function(groups) {
-    res.mjson(groups);
-  })
-  .catch(function(error) {
-    next(error);
-  });
-
+  .then( res.mjson )
+  .catch( next );
 };
-
 
 exp.addGroup = function (req, res, next) {
 
@@ -37,18 +22,12 @@ exp.addGroup = function (req, res, next) {
 
   var group = new Group();
   
-  group.name = req.body.name;
+  group.name   = req.body.name;
+  group.topics = req.body.topics;
 
-  var topics = req.body.topics;
-  
-  for(var i in topics) {
-    group.topics.push(ObjectId(topics[i]))
-  }
-  
-  group.save( function (err, group) {
-    if (err) return next(err);
-    res.json(group)
-  });
+  group.save()
+  .then( res.json )
+  .error( next );
 
 };
 
@@ -63,22 +42,21 @@ exp.updateTopics = function (req, res, next) {
     { '_id': req.params.groupId }
   ).exec();
 
-  updateTopics.addBack( function (err, group) {
-    if (err) return next(err);
-
-    if (group) { 
-      
+  Group.findById(req.params.groupId)
+  .then( function(group) {
+    if (group) {
       for (var i in topics) {
         if (group.topics.indexOf(topics[i]) === -1) {
-          group.topics.push(ObjectId(topics[i]));
+          group.topics.push(topics[i]);
         }  
       }
-
-      group.save();
+      return group.save();
+    } else {
+      return group;
     }
-
-    res.json(group);
-  });
+  })
+  .then( res.json )
+  .catch( next);
 
 };
 
@@ -90,11 +68,8 @@ exp.deleteGroup = function (req, res, next) {
   var deleteGroup = Group.update(
     { '_id': req.params.groupId },
     { $set: { 'deleted': true } }
-  ).exec();
-
-  deleteGroup.addBack( function (err, updated, raw) {
-    if (err) return next(err);
-    res.json(raw);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 
 };

--- a/Server/controllers/groups.js
+++ b/Server/controllers/groups.js
@@ -5,15 +5,11 @@ var exp = module.exports;
 
 
 exp.findById = function (req, res, next) {
-  Group.findById(req.params.groupId)
-  .then( res.json )
-  .catch( next );
+  return Group.findById(req.params.groupId);
 };
 
 exp.findAll = function (req, res, next) {
-  Group.find()
-  .then( res.mjson )
-  .catch( next );
+  return Group.find();
 };
 
 exp.addGroup = function (req, res, next) {
@@ -25,9 +21,7 @@ exp.addGroup = function (req, res, next) {
   group.name   = req.body.name;
   group.topics = req.body.topics;
 
-  group.save()
-  .then( res.json )
-  .error( next );
+  return group.save();
 
 };
 
@@ -38,11 +32,7 @@ exp.updateTopics = function (req, res, next) {
 
   var topics = req.body.topics;
 
-  var updateTopics = Group.findOne(
-    { '_id': req.params.groupId }
-  ).exec();
-
-  Group.findById(req.params.groupId)
+  return Group.findById(req.params.groupId)
   .then( function(group) {
     if (group) {
       for (var i in topics) {
@@ -54,9 +44,7 @@ exp.updateTopics = function (req, res, next) {
     } else {
       return group;
     }
-  })
-  .then( res.json )
-  .catch( next);
+  });
 
 };
 
@@ -65,11 +53,9 @@ exp.deleteGroup = function (req, res, next) {
   
   // TODO add auth info ensure only mods and admin can delete
 
-  var deleteGroup = Group.update(
+  return Group.update(
     { '_id': req.params.groupId },
     { $set: { 'deleted': true } }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 
 };

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -6,24 +6,15 @@ var exp = module.exports;
 
 exp.findByQuestionId = function (req, res, next) {
   Question.findById(req.params.questionId)
-  .then(
-      function(result) {
-        return res.mjson(result);
-      },
-      function(error) {
-        return next(error)
-      }
-  );
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
   Question.find()
-  .populate('author', 'username')
-  .exec( function (err, questions) {
-    if(err) return next(err);
-    res.mjson(questions)
-  });
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.addQuestion = function (req, res, next) {
@@ -37,24 +28,15 @@ exp.addQuestion = function (req, res, next) {
   question.message      = req.body.message;
   question.group        = req.body.group;
   question.topics       = req.body.topics;
-  //question.images.      push(req.body.imageUrl);
-  //question.videos.      push(req.body.videoUrl);
-  //question.code.        push(req.body.code);
   question.upVotes.     push(req.user._id);
 
   question.save()
-  .then(function(question) {
-    res.json(question);
-  })
-  .catch(function(error) {
-    console.error(error);
-    next(error);
-  })
+  .then( res.json )
+  .catch( next );
 };
 
 exp.updateQuestion = function (req, res, next) {
 // TODO add auth info ensure only user and admin can update
-	console.log(req.body);
   Question.findById(req.params.questionId)
   .then(function(question) {
     question.message = req.body.message;
@@ -64,40 +46,26 @@ exp.updateQuestion = function (req, res, next) {
     question.dateModified = new Date();
     return question.save();
   })
-  .then(function(updatedQuestion) {
-    res.mjson(updatedQuestion);
-  })
-  .catch( function(error) {
-    console.error(error);
-    return next(error);
-  });
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.deleteQuestion = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-    Question.setAsDeleted(req.params.questionId, req.user._id).then(
-      res.mjson,
-      next
-    );
+    Question.setAsDeleted(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.upVoteQuestion = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.mjson(upVoted);
-    }
-
-    Question.upVote(req.params.questionId, req.user._id, done)
+    Question.upVote(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.downVoteQuestion = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.mjson(downVoted);
-    }
-
-    Question.downVote(req.params.questionId, req.user._id, done)
+    Question.downVote(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -10,7 +10,11 @@ exp.findByQuestionId = function (req, res, next) {
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
-  return Question.find()
+  if (req.params.groupID) {
+    return Question.find({'group': req.params.groupID});
+  } else {
+    return Question.find()
+  }
 };
 
 exp.addQuestion = function (req, res, next) {

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -36,16 +36,11 @@ exp.addQuestion = function (req, res, next) {
   question.anonymous    = req.body.anonymous;
   question.message      = req.body.message;
   question.group        = req.body.group;
+  question.topics       = req.body.topics;
   //question.images.      push(req.body.imageUrl);
   //question.videos.      push(req.body.videoUrl);
   //question.code.        push(req.body.code);
   question.upVotes.     push(req.user._id);
-
-  var topics = req.body.topics;
-
-  for (var i in topics) {
-  	question.topics.push(topics[i])
-  }
 
   question.save( function (err, question) {
     if (err) return next(err);
@@ -61,6 +56,8 @@ exp.updateQuestion = function (req, res, next) {
   .then(function(question) {
     question.message = req.body.message;
     question.title = req.body.title;
+    question.group        = req.body.group;
+    question.topics        = req.body.topics;
     question.dateModified = new Date();
     return question.save();
   }).then(

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -42,11 +42,14 @@ exp.addQuestion = function (req, res, next) {
   //question.code.        push(req.body.code);
   question.upVotes.     push(req.user._id);
 
-  question.save( function (err, question) {
-    if (err) return next(err);
+  question.save()
+  .then(function(question) {
     res.json(question);
-    console.log(question);
-  });
+  })
+  .catch(function(error) {
+    console.error(error);
+    next(error);
+  })
 };
 
 exp.updateQuestion = function (req, res, next) {
@@ -60,14 +63,14 @@ exp.updateQuestion = function (req, res, next) {
     question.topics        = req.body.topics;
     question.dateModified = new Date();
     return question.save();
-  }).then(
-    function(updatedQuestion) {
-      res.mjson(updatedQuestion);
-    },
-    function(error) {
-      return next(error);
-    }
-  );
+  })
+  .then(function(updatedQuestion) {
+    res.mjson(updatedQuestion);
+  })
+  .catch( function(error) {
+    console.error(error);
+    return next(error);
+  });
 };
 
 exp.deleteQuestion = function(req, res, next) {

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -5,16 +5,12 @@ var Question = require('../models/question');
 var exp = module.exports;
 
 exp.findByQuestionId = function (req, res, next) {
-  Question.findById(req.params.questionId)
-  .then( res.mjson )
-  .catch( next );
+  return Question.findById(req.params.questionId)
 };
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
-  Question.find()
-  .then( res.mjson )
-  .catch( next );
+  return Question.find()
 };
 
 exp.addQuestion = function (req, res, next) {
@@ -30,14 +26,12 @@ exp.addQuestion = function (req, res, next) {
   question.topics       = req.body.topics;
   question.upVotes.     push(req.user._id);
 
-  question.save()
-  .then( res.json )
-  .catch( next );
+  return question.save()
 };
 
 exp.updateQuestion = function (req, res, next) {
 // TODO add auth info ensure only user and admin can update
-  Question.findById(req.params.questionId)
+  return Question.findById(req.params.questionId)
   .then(function(question) {
     question.message = req.body.message;
     question.title = req.body.title;
@@ -46,26 +40,18 @@ exp.updateQuestion = function (req, res, next) {
     question.dateModified = new Date();
     return question.save();
   })
-  .then( res.mjson )
-  .catch( next );
 };
 
 exp.deleteQuestion = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-    Question.setAsDeleted(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.setAsDeleted(req.params.questionId, req.user._id)
 };
 
 exp.upVoteQuestion = function(req, res, next) {
-    Question.upVote(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.upVote(req.params.questionId, req.user._id)
 };
 
 exp.downVoteQuestion = function(req, res, next) {
-    Question.downVote(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.downVote(req.params.questionId, req.user._id)
 };

--- a/Server/controllers/topics.js
+++ b/Server/controllers/topics.js
@@ -5,9 +5,7 @@ var exp = module.exports;
 
 exp.findById = function (req, res, next) {
 
-  Topic.findById(req.params.topicId)
-  .then( res.json )
-  .catch( next );
+  return Topic.findById(req.params.topicId);
 
 };
 
@@ -21,9 +19,7 @@ exp.findByName = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  Topic.find()
-  .then( res.mjson )
-  .catch( next );
+  return Topic.find();
 };
 
 
@@ -35,9 +31,7 @@ exp.addTopic = function (req, res, next) {
   // TODO set case of topic (all lower?)
   topic.name = req.body.name;
 
-  topic.save()
-  .then( res.json )
-  .catch( next );
+  return topic.save();
 
 };
 
@@ -46,11 +40,9 @@ exp.deleteTopic = function (req, res, next) {
   
   // TODO check if user is admin
 
-  Topic.update(
+  return Topic.update(
     { '_id': req.params.topicId },
     { $set: { 'deleted': true } }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 
 };

--- a/Server/controllers/topics.js
+++ b/Server/controllers/topics.js
@@ -5,15 +5,9 @@ var exp = module.exports;
 
 exp.findById = function (req, res, next) {
 
-  Topic.findOne(
-    { '_id': new ObjectId(req.params.topicId) }
-  )
-  .then( function (topic) {
-    res.json(topic);
-  })
-  .catch(function(error) {
-    return next(error)
-  });
+  Topic.findById(req.params.topicId)
+  .then( res.json )
+  .catch( next );
 
 };
 
@@ -27,14 +21,9 @@ exp.findByName = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  Topic.find().exec()
-  .then( function (topics) {
-    res.mjson(topics);
-  })
-  .catch(function(error) {
-    return next(error)
-  });
-
+  Topic.find()
+  .then( res.mjson )
+  .catch( next );
 };
 
 
@@ -46,10 +35,9 @@ exp.addTopic = function (req, res, next) {
   // TODO set case of topic (all lower?)
   topic.name = req.body.name;
 
-  topic.save( function (err, topic) {
-    if (err) return next(err);
-    res.json(topic)
-  });
+  topic.save()
+  .then( res.json )
+  .catch( next );
 
 };
 
@@ -58,14 +46,11 @@ exp.deleteTopic = function (req, res, next) {
   
   // TODO check if user is admin
 
-  var deleteTopic = Topic.update(
+  Topic.update(
     { '_id': req.params.topicId },
     { $set: { 'deleted': true } }
-  ).exec();
-
-  deleteTopic.addBack( function (err, updated, raw) {
-    if (err) return next(err);
-    res.json(raw);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 
 };

--- a/Server/controllers/topics.js
+++ b/Server/controllers/topics.js
@@ -5,13 +5,14 @@ var exp = module.exports;
 
 exp.findById = function (req, res, next) {
 
-  var getTopic = Topic.findOne(
+  Topic.findOne(
     { '_id': new ObjectId(req.params.topicId) }
-  ).exec();
-
-  getTopic.addBack( function (err, topic) {
-    if (err) return next(err);
+  )
+  .then( function (topic) {
     res.json(topic);
+  })
+  .catch(function(error) {
+    return next(error)
   });
 
 };
@@ -26,12 +27,13 @@ exp.findByName = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  var getTopics = Topic.find().exec();
-
-  getTopics.addBack( function (err, topics) {
-    if (err) return next(err);
-    res.json(topics);
+  Topic.find().exec()
+  .then( function (topics) {
+    res.mjson(topics);
   })
+  .catch(function(error) {
+    return next(error)
+  });
 
 };
 

--- a/Server/controllers/users.js
+++ b/Server/controllers/users.js
@@ -4,15 +4,11 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findUserById = function (req, res, next) {
-  User.findById(req.params.userId)
-  .then( res.json )
-  .catch( next );
+  return User.findById(req.params.userId);
 };
 
 exp.findUserByUsername = function (req, res, next) {
-  User.findOne(
+  return User.findOne(
     { 'local.username': req.body.username }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 };

--- a/Server/controllers/users.js
+++ b/Server/controllers/users.js
@@ -4,23 +4,15 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findUserById = function (req, res, next) {
-  var getUser = User.findOne(
-    { '_id': new ObjectId(req.params.userId) }
-  ).exec();
-
-  getUser.addBack( function (err, user) {
-    if (err) return next(err);
-    res.json(user);
-  });
+  User.findById(req.params.userId)
+  .then( res.json )
+  .catch( next );
 };
 
 exp.findUserByUsername = function (req, res, next) {
-  var getUser = User.findOne(
+  User.findOne(
     { 'local.username': req.body.username }
-  ).exec();
-
-  getUser.addBack( function (err, user) {
-    if (err) return next(err);
-    res.json(user);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 };

--- a/Server/models/common/contentMethods.js
+++ b/Server/models/common/contentMethods.js
@@ -8,26 +8,27 @@ var ObjectId 		= require('mongoose').Schema.Types.ObjectId;
 
 var autoPopulate 	= require('mongoose-autopopulate');
 
-var upVote = function (contentId, userId, cb) {
+var upVote = function (contentId, userId) {
 	return this.update({'_id': contentId},
 		{
 			$pull: {'downVotes': userId},
 			$addToSet: {'upVotes': userId}
-		}).exec(cb);
+		});
 }
 
-var downVote = function (contentId, userId, cb) {
+var downVote = function (contentId, userId) {
 	return this.update({'_id': contentId},
 		{	
 			$pull: {'upVotes': userId},
 			$addToSet: {'downVotes': userId}
-		}).exec(cb);
+		});
 }
 
-var removeVotes = function (contentId, userId, cb) {
+var removeVotes = function (contentId, userId) {
 	return this.update({'_id': contentId},
-		{$pull: {'upVotes': userId, 'downVotes': userId}})
-	.exec(cb);
+		{
+			$pull: {'upVotes': userId, 'downVotes': userId}
+		});
 }
 
 var setAsDeleted = function (contentId, userId) {

--- a/Server/models/group.js
+++ b/Server/models/group.js
@@ -1,17 +1,31 @@
 var mongoose = require('mongoose');
 var objectId = mongoose.Schema.Types.ObjectId;
+var Topic = require('./topic');
 
 // Schema definition
 var groupSchema = mongoose.Schema({
-    name:           { type: String, required: true },
+    _id:            { type: String, required: true, unique: true }, 
+    name:           { type: String, required: true, unique: true },
     dateCreated:    { type: Date, default: Date.now },
     dateModified:   { type: Date, default: null },
-    topics:         [{ type: objectId, ref: 'Topic' }],
+    topics:         {
+    		type: Array,
+    		schema: {
+    			type: objectId,
+    			ref: 'Topic'
+    		}
+    	},
+    unitCode:       {type: String, required: false },
+    title:          {type: String, required: false },
     deleted:        { type: Boolean, default: false }
 })
 
-// Indexes
-groupSchema.path('name').index({text : true});
 
+// Indexes
+groupSchema.path('name').index({text : true, unique: true});
+groupSchema.pre('validate', function(next) {
+    this._id = this.unitCode || this.name;
+    next();
+});
 
 module.exports = mongoose.model('Group', groupSchema);

--- a/Server/models/question.js
+++ b/Server/models/question.js
@@ -12,8 +12,8 @@ var autoPopulate 	= require('mongoose-autopopulate');
 // Schema definition
 var questionSchema = new contentMethods.BaseContentSchema({
     title:          { type: String, required: true },
-    topics:         [{ type: objectId, ref: 'Topic' }],
-    group:          { type: objectId, ref: 'Group', required: false }, //TODO: SET REQUIRED TO TRUE!!
+    topics:         [{ type: String, ref: 'Topic' }],
+    group:          { type: String, ref: 'Group', required: false }, //TODO: SET REQUIRED TO TRUE!!
     answers:        {
     					type: Array,
     					schema: objectId, ref: 'Answer',

--- a/Server/models/question.js
+++ b/Server/models/question.js
@@ -13,7 +13,7 @@ var autoPopulate 	= require('mongoose-autopopulate');
 var questionSchema = new contentMethods.BaseContentSchema({
     title:          { type: String, required: true },
     topics:         [{ type: String, ref: 'Topic' }],
-    group:          { type: String, ref: 'Group', required: false }, //TODO: SET REQUIRED TO TRUE!!
+    group:          { type: String, required: false }, //TODO: SET REQUIRED TO TRUE!!
     answers:        {
     					type: Array,
     					schema: objectId, ref: 'Answer',

--- a/Server/models/topic.js
+++ b/Server/models/topic.js
@@ -3,6 +3,7 @@ var objectId = mongoose.Schema.Types.ObjectId;
 
 // Schema definition
 var topicSchema = mongoose.Schema({
+    _id:            { type: String, required: true, unique: true }, 
     name:           { type: String, required: true },
     dateCreated:    { type: Date, default: Date.now },
     dateModified:   { type: Date, default: null },
@@ -11,6 +12,10 @@ var topicSchema = mongoose.Schema({
 
 // Indexes
 topicSchema.path('name').index({text : true});
+topicSchema.pre('validate', function(next) {
+	this._id = this.name;
+	next();
+});
 
 
 module.exports = mongoose.model('Topic', topicSchema);

--- a/Server/models/user.js
+++ b/Server/models/user.js
@@ -10,8 +10,8 @@ var userSchema = mongoose.Schema({
     email:          String,
     dateCreated:    { type: Date, default: Date.now },
     dateModified:   { type: Date, default: null },
-    subscriptions:  [{ type: objectId, active: Boolean }],
-    enrollments:    [{ type: objectId, active: Boolean }],
+    subscriptions:  [String],
+    enrollments:    [String],
     isAdmin:        { type: Boolean, default: false },
     moderatorOf:    [{ type: objectId, ref: 'Group' }]
 })

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -73,6 +73,7 @@ promisedRouter.get('/user/:username', usersCtrl.findUserByUsername);
 // Question Routes
 promisedRouter.post('/questions', questionsCtrl.addQuestion);
 promisedRouter.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
+promisedRouter.get('/questions/tenMore/:groupID/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
 promisedRouter.get('/questions/:questionId', questionsCtrl.findByQuestionId);
 promisedRouter.put('/questions/:questionId', questionsCtrl.updateQuestion);
 promisedRouter.delete('/questions/:questionId', questionsCtrl.deleteQuestion);

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -25,52 +25,90 @@ function authWrite(req, res, next) {
 	}
 }
 
+// call this with a route controller that returns a promise, for fun and profit.
+// function getQuestions(req, res, next) {
+//   Question.find()
+//   .then( function(q) { res.json(q) } )
+//   .catch( function(error) { next(error) }) ;
+// }
+//
+// is equivalent to
+// function getQuestionSimple(req) {
+//   return Question.find();
+// }
+//
+// jsonRoute(getQuestionsSimple);
+
+
+function jsonRoute(jsonPromise) {
+	return function(req, res, next) {
+		jsonPromise(req, res, next)
+		.then(function(promiseResult) {
+			res.mjson(promiseResult);
+		})
+		.catch( function(error) {
+			console.log(error);
+			next(error)
+		});
+	}
+}
+
+var promisedRouter = {};
+
+//now promisedRouter.get('/route', ctrl.doSomething)
+//    == router.get('/route', jsonRoute(ctrl.doSomething));
+['get','post','put','delete','patch'].forEach(function(action) {
+	promisedRouter[action] = function(route, jsonPromise) {
+		return router[action](route, jsonRoute(jsonPromise));
+	}
+});
+
 // All API routes require auth
 router.use(authWrite)
 
 // User Routes
-router.get('/user/:userId', usersCtrl.findUserById);
-router.get('/user/:username', usersCtrl.findUserByUsername);
+promisedRouter.get('/user/:userId', usersCtrl.findUserById);
+promisedRouter.get('/user/:username', usersCtrl.findUserByUsername);
 
 // Question Routes
-router.post('/questions', questionsCtrl.addQuestion);
-router.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
-router.get('/questions/:questionId', questionsCtrl.findByQuestionId);
-router.put('/questions/:questionId', questionsCtrl.updateQuestion);
-router.delete('/questions/:questionId', questionsCtrl.deleteQuestion);
-router.put('/questions/upvote/:questionId', questionsCtrl.upVoteQuestion);
-router.put('/questions/downvote/:questionId', questionsCtrl.downVoteQuestion);
+promisedRouter.post('/questions', questionsCtrl.addQuestion);
+promisedRouter.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
+promisedRouter.get('/questions/:questionId', questionsCtrl.findByQuestionId);
+promisedRouter.put('/questions/:questionId', questionsCtrl.updateQuestion);
+promisedRouter.delete('/questions/:questionId', questionsCtrl.deleteQuestion);
+promisedRouter.put('/questions/upvote/:questionId', questionsCtrl.upVoteQuestion);
+promisedRouter.put('/questions/downvote/:questionId', questionsCtrl.downVoteQuestion);
 
 // Answer Routes
-router.get('/answers/:questionId', answersCtrl.findByQuestionId);
-router.post('/answers/:questionId', answersCtrl.addByQuestionId);
-router.delete('/answers/:answerId', answersCtrl.deleteAnswer);
-router.put('/answers/upvote/:answerId', answersCtrl.upVoteAnswer);
-router.put('/answers/downvote/:answerId', answersCtrl.downVoteAnswer);
+promisedRouter.get('/answers/:questionId', answersCtrl.findByQuestionId);
+promisedRouter.post('/answers/:questionId', answersCtrl.addByQuestionId);
+promisedRouter.delete('/answers/:answerId', answersCtrl.deleteAnswer);
+promisedRouter.put('/answers/upvote/:answerId', answersCtrl.upVoteAnswer);
+promisedRouter.put('/answers/downvote/:answerId', answersCtrl.downVoteAnswer);
 
 // Comment Routes
 // to be called as comment?questionId=id&answerId=id
-router.get('/comments', commentsCtrl.findByQAId);
-router.get('/comments/:commentId', commentsCtrl.findByCommentId);
-router.post('/comments/:parentId', commentsCtrl.addByQAId);
-router.delete('/comments/:commentId', commentsCtrl.deleteComment);
-router.put('/comments/:commentId', commentsCtrl.updateComment);
-router.put('/comments/upvote/:commentId', commentsCtrl.upVoteComment);
-router.put('/comments/downvote/:commentId', commentsCtrl.downVoteComment);
+promisedRouter.get('/comments', commentsCtrl.findByQAId);
+promisedRouter.get('/comments/:commentId', commentsCtrl.findByCommentId);
+promisedRouter.post('/comments/:parentId', commentsCtrl.addByQAId);
+promisedRouter.delete('/comments/:commentId', commentsCtrl.deleteComment);
+promisedRouter.put('/comments/:commentId', commentsCtrl.updateComment);
+promisedRouter.put('/comments/upvote/:commentId', commentsCtrl.upVoteComment);
+promisedRouter.put('/comments/downvote/:commentId', commentsCtrl.downVoteComment);
 
 // Group Routes
-router.get('/groups', groupsCtrl.findAll);
-router.post('/groups', groupsCtrl.addGroup);
-router.get('/groups/:groupId', groupsCtrl.findById);
-router.put('/groups/:groupId', groupsCtrl.updateTopics);
-router.delete('/groups/:groupId', groupsCtrl.deleteGroup);
+promisedRouter.get('/groups', groupsCtrl.findAll);
+promisedRouter.post('/groups', groupsCtrl.addGroup);
+promisedRouter.get('/groups/:groupId', groupsCtrl.findById);
+promisedRouter.put('/groups/:groupId', groupsCtrl.updateTopics);
+promisedRouter.delete('/groups/:groupId', groupsCtrl.deleteGroup);
 
 // Topic Routes
-router.get('/topics', topicsCtrl.findAll);
-router.post('/topics', topicsCtrl.addTopic);
-router.get('/topics/:topicId', topicsCtrl.findById);
-router.get('/topics/name/:topicName', topicsCtrl.findByName);
-router.delete('/topics/:topicId', topicsCtrl.deleteTopic);
+promisedRouter.get('/topics', topicsCtrl.findAll);
+promisedRouter.post('/topics', topicsCtrl.addTopic);
+promisedRouter.get('/topics/:topicId', topicsCtrl.findById);
+promisedRouter.get('/topics/name/:topicName', topicsCtrl.findByName);
+promisedRouter.delete('/topics/:topicId', topicsCtrl.deleteTopic);
 
 
 module.exports = router;

--- a/Server/server.js
+++ b/Server/server.js
@@ -102,13 +102,15 @@ app.use(function(req, res, next) {
 });
 
 // Add routes
-var account = require('./routes/account')(passport);
-var api 	= require('./routes/api');
+var account = require(here('./routes/account'))(passport);
+var api 	= require(here('./routes/api'));
 var baucis  = require(here('config/baucis'));
 
 app.use('/account', account);
 app.use('/api', api);
 app.use('/rest', baucis());
+
+require(here('config/groups'));
 
 /// Catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/Server/server.js
+++ b/Server/server.js
@@ -44,6 +44,8 @@ app.options = options;
 
 // Configure database
 var dbConfig = require(here('config/database.js'));
+
+mongoose.Promise = global.Promise;
 mongoose.connect(dbConfig.url);
 var db = mongoose.connection;
 db.on('error', console.error.bind(console, 'connection error:'));


### PR DESCRIPTION
We now show the logged in user's enrolments in the side pane (oh shit, I just realized our schema has 'enrollments' spelled incorrectly), and can browse a specific group by going to /kusema/groups/eng1030 -- the links on the side have already been updated to this. If you want to test it, you'll have to use a non-authcate account and manually hack your enrolments to be e.g. ['eng1003', 'eng1060'] for now, unless you happen to have access to a first-year student account. oooh actually we'll test your staff account -- LDAP is returning teaching commitments so I'm grabbing those too (see previous userFun PR), but I'm not sure if they're kept up to date, I snooped at Jon's and they looked old.

Jarrad