### PR TITLE
Subscriptions cleanup

### DIFF
--- a/Client/app.js
+++ b/Client/app.js
@@ -43,28 +43,13 @@ kusema.config(function (
     .when('','/kusema')
     .when('/','/kusema');
 
-
-  /*
-  .state('/question/:id', {
-    templateUrl: 'user/question/question.html',
-  })
-  .when('/group/:id', {
-    templateUrl: 'user/group/group.html',
-  })
-  .when('/newcomment/:id', {
-	  templateUrl: 'views/newComment.html',
-  })
-  .when('/newquestion/', {
-	  templateUrl: 'views/newQuestion.html',
-  })
-  .when('/newunit/', {
-	  templateUrl: 'views/newUnit.html',
-  })
-  .when('/newarea/', {
-	  templateUrl: 'views/newArea.html',
-  });*/
   
 });
+
+kusema.run(['$rootScope', '$stateParams', function($rootScope, $stateParams) {
+  $rootScope.$stateParams = $stateParams;
+  console.log('hellooooo! :)');
+}]);
 
 /*
 kusema.addModule(string moduleName, dependencies=[], autoRequire=true)

--- a/Client/common/components/Markdown/markdown.js
+++ b/Client/common/components/Markdown/markdown.js
@@ -34,12 +34,6 @@ markdownController.prototype = Object.create(Object.prototype, {
 markdownController.prototype.updateOutput = function() {
 	if (this.md && this._input) {
 		var renderer = (this.inline) ? this.md.renderInline.bind(this.md) : this.md.render.bind(this.md);
-		if (this.inline) {
-			console.log('rendering inline: '+this.input);
-		} else {
-			console.log('rendering full: '+this.input);
-
-		}
 		this.output = this.$sce.trustAsHtml(renderer(this.input));
 	}
 } 

--- a/Client/common/services/GroupService.js
+++ b/Client/common/services/GroupService.js
@@ -49,9 +49,9 @@ var GroupService = function($rootScope, $http, topicService, kusemaConfig, login
 	GroupService.prototype.updateUserGroups = function() {
 		this.bindables.userGroups =  ( 
 			(this.loginService.bindables.loginState > 0)
-	     	&& (this.loginService.bindables.user.enrolments)
+	     	&& (this.loginService.bindables.user.subscriptions.groups)
      	)
-     		? this.getGroups(this.loginService.bindables.user.enrolments)
+     		? this.getGroups(this.loginService.bindables.user.subscriptions.groups)
 	     	: this.bindables.groups;
 	}
 

--- a/Client/common/services/GroupService.js
+++ b/Client/common/services/GroupService.js
@@ -49,9 +49,9 @@ var GroupService = function($rootScope, $http, topicService, kusemaConfig, login
 	GroupService.prototype.updateUserGroups = function() {
 		this.bindables.userGroups =  ( 
 			(this.loginService.bindables.loginState > 0)
-	     	&& (this.loginService.bindables.user.enrollments)
+	     	&& (this.loginService.bindables.user.enrolments)
      	)
-     		? this.getGroups(this.loginService.bindables.user.enrollments)
+     		? this.getGroups(this.loginService.bindables.user.enrolments)
 	     	: this.bindables.groups;
 	}
 

--- a/Client/common/services/LoginService.js
+++ b/Client/common/services/LoginService.js
@@ -48,15 +48,15 @@ var LoginService = function($http, $rootScope, kusemaConfig) {
 		return this.$http.post(
 							this.kusemaConfig.url()+'account/login_local',
 							{'username': username, 'password': password}
-						).then(
-						function(response) {
+						)
+						.then( function(response) {
 							console.log('login request done');
 							return this.checkLogin();
-						}.bind(this),
-						function(error) {
+						}.bind(this))
+						.catch( function(error) {
+							this.loginState = 0;
 							console.log('login error');
-						}
-					);
+						}.bind(this));
 	};
 	LoginService.prototype.logout = function() {
 		var logoutRequest = this.$http.post(this.kusemaConfig.url()+'account/logout');

--- a/Client/common/services/QuestionService.js
+++ b/Client/common/services/QuestionService.js
@@ -11,11 +11,12 @@ var QuestionService = function($http, kusemaConfig, socketFactory, answerService
 		model: {writable: false, enumerable: false, value: Question}
 	});
 
-	QuestionService.prototype.getNextTenQuestions = function (requestNumber) {
-	        return this.$http.get(this.urlBase + '/tenMore/' + requestNumber)
-	                    .then(function(response) {
-	                        return this.createClientModels(response.data);
-	                    }.bind(this));
+	QuestionService.prototype.getNextTenQuestions = function (requestNumber, group) {
+		var groupURL = (group) ? ('/'+group) : '';
+        return this.$http.get(this.urlBase + '/tenMore' + groupURL + '/' + requestNumber)
+                    .then(function(response) {
+                        return this.createClientModels(response.data);
+                    }.bind(this));
 	    };
 	    
 

--- a/Client/user/kusemaUser.js
+++ b/Client/user/kusemaUser.js
@@ -4,6 +4,10 @@ var KusemaUserConfig = function($stateProvider) {
 		    url: '',
 		    template: '<kusema-question-list></kusema-question-list>'
 		})
+		.state('user.group', {
+		    url: '/group/:groupID',
+		    template: '<kusema-question-list group="$root.$stateParams.groupID"></kusema-question-list>'
+		})
 		.state('user.question', {
 			url: '/question/:id',
 			template: '<kusema-question-full></kusema-question-full>'

--- a/Client/user/kusemaUserTemplate.html
+++ b/Client/user/kusemaUserTemplate.html
@@ -20,8 +20,8 @@
     <h2 class="md-subhead">Groups</h2>
     <md-content>
     <ul style="list-style-type: none; padding: 0;">
-    <li ng-repeat="group in groupServiceData.groups">
-      <a href="group/{{group.code}}" ng-bind="group.name"></a>
+    <li ng-repeat="group in groupServiceData.userGroups">
+      <a ui-sref="user.group({groupID: group._id})" ng-bind="group.name"></a>
     </li>
     <li style="padding-bottom: 10px;"><a style="text-decoration: none;" href="">+ Make a group</a></li>
     </ul>

--- a/Client/user/questionList/questionList.js
+++ b/Client/user/questionList/questionList.js
@@ -28,7 +28,8 @@
 
 var QuestionListDirective = function() {
 	return {
-		scope: {
+		scope: {},
+		bindToController: {
 			'group': '='
 		},
 		templateUrl: 'user/questionList/questionListTemplate.html',
@@ -68,7 +69,7 @@ var QuestionListController = function(questionFactory, $mdDialog, $scope) {
 	      }
 	    };
 
-	    questionFactory.getNextTenQuestions(0)
+	    questionFactory.getNextTenQuestions(0, this.group)
 	    .then(
 	        function (quest) {
 	            this.questions.addQuestions(quest);

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -14,7 +14,6 @@ exp.findByQuestionId = function(req, res, next) {
 };
 
 exp.addByQuestionId = function(req, res, next) {
-
     var answer = new Answer();
     
     answer.author       = new ObjectId(req.user._id);
@@ -23,32 +22,22 @@ exp.addByQuestionId = function(req, res, next) {
     answer.question     = new ObjectId(req.params.questionId);
     answer.upVotes.     push(req.user._id);
 
-    answer.save()
+    return answer.save()
     .then( function(answer) {
-            // if we want out plugins to run, i.e. autopopulation, then we need to run a database find :(
-            Answer.findById(answer._id).then(res.mjson.bind(res));
-    })
-    .catch( function (error) {
-            next(error);
+            // if we want our plugins to run, i.e. autopopulation, then we need to run a database find :(
+            return Answer.findById(answer._id)
     });
-};
+}
 
 exp.deleteAnswer = function(req, res, next) {
-  
     // TODO add auth info ensure only creator, mods and admin can delete
-    Answer.setAsDeleted(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Answer.setAsDeleted(req.params.answerId, req.user._id);
 };
 
 exp.upVoteAnswer = function(req, res, next) {
-    Answer.upVote(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Answer.upVote(req.params.answerId, req.user._id);
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-    Answer.downVote(req.params.answerId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    Answer.downVote(req.params.answerId, req.user._id);
 };

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -4,12 +4,9 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findByQuestionId = function(req, res, next) {
-    Question.findById(req.params.questionId)
+    return Question.findById(req.params.questionId)
     .then( function(question) {
-        res.json(question.answers);
-    })
-    .catch( function(error) {
-        next(error);
+        return question.answers;
     });
 };
 
@@ -39,5 +36,5 @@ exp.upVoteAnswer = function(req, res, next) {
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-    Answer.downVote(req.params.answerId, req.user._id);
+    return Answer.downVote(req.params.answerId, req.user._id);
 };

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -5,14 +5,12 @@ var exp = module.exports;
 
 exp.findByQuestionId = function(req, res, next) {
     Question.findById(req.params.questionId)
-    .then(
-        function(question) {
-            res.json(question.answers);
-        },
-        function(error) {
-            next(error);
-        }
-    );
+    .then( function(question) {
+        res.json(question.answers);
+    })
+    .catch( function(error) {
+        next(error);
+    });
 };
 
 exp.addByQuestionId = function(req, res, next) {
@@ -22,45 +20,35 @@ exp.addByQuestionId = function(req, res, next) {
     answer.author       = new ObjectId(req.user._id);
     answer.anonymous    = req.body.anonymous;
     answer.message      = req.body.message;
-    answer.question   = new ObjectId(req.params.questionId);
+    answer.question     = new ObjectId(req.params.questionId);
     answer.upVotes.     push(req.user._id);
 
-    answer.save().then(
-        function(answer) {
+    answer.save()
+    .then( function(answer) {
             // if we want out plugins to run, i.e. autopopulation, then we need to run a database find :(
             Answer.findById(answer._id).then(res.mjson.bind(res));
-        },
-        function (error) {
+    })
+    .catch( function (error) {
             next(error);
-        });
+    });
 };
 
 exp.deleteAnswer = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-
-    Answer.setAsDeleted(req.params.answerId, req.user._id).then(
-        res.json,
-        next
-    );
+    Answer.setAsDeleted(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.upVoteAnswer = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.json(upVoted);
-    }
-
-    Answer.upVote(req.params.answerId, req.user._id, done)
+    Answer.upVote(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.downVoteAnswer = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.json(downVoted);
-    }
-
-    Answer.downVote(req.params.answerId, req.user._id, done)
+    Answer.downVote(req.params.answerId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -17,75 +17,56 @@ exp.findByQAId = function(req, res, next) {
 		findQuery.push({underscoreProperty: valueToPush});
 	});
 
-	var getComments = Comment.find({$and: findQuery}).exec();
-
-	getComments.addBack(function (err, comments) {
-		if (err) return next(err);
-		res.json(comments);
-	})
+	Comment.find({$and: findQuery})
+	.then( res.json )
+	.catch( next );
 };
 
 exp.addByQAId = function(req, res, next) {
 	var comment = new Comment();
 
-	comment.author = req.user._id;
+	comment.author  = req.user._id;
 	comment.message = req.body.message;
-	comment.parent = new ObjectId(req.params.parentId);
+	comment.parent  = new ObjectId(req.params.parentId);
 
-	comment.save( function (err, comment) {
-		if (err) return next(err);
-		res.json(comment)
-	});
+	comment.save()
+	.then( res.json )
+	.catch ( next );
 };
 
 exp.findByCommentId = function(req, res, next) {
-	var getComment = Comment.findById(req.params.commentId).exec();
-	getComment.addBack(function (err, comment) {
-		if (err) return next(err);
-		res.json(comment);
-	});
+	Comment.findById(req.params.commentId)
+	.then( res.json )
+	.catch( next );
 }
 
 exp.updateComment = function(req, res, next) {
-	Comment.findById(req.params.commentId).then(
-		function(comment) {
-			comment.message = req.body.message;
-			return comment.save();
-		}).then(
-		function(savedComment) {
-			res.json(savedComment);
-		},
-		function(error) {
-			return next(error);
-		});
+	Comment.findById(req.params.commentId)
+	.then( function(comment) {
+		comment.message = req.body.message;
+		return comment.save();
+	})
+	.then( res.json )
+	.catch( next );
 }
 
 exp.deleteComment = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
 
-    Comment.setAsDeleted(req.params.commentId, req.user._id).then(
-    	res.mjson,
-    	next
-    );
+    Comment.setAsDeleted(req.params.commentId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.upVoteComment = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.json(upVoted);
-    }
-
-    Comment.upVote(req.params.commentId, req.user._id, done)
+    Comment.upVote(req.params.commentId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };
 
 exp.downVoteComment = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.json(downVoted);
-    }
-
-    Comment.downVote(req.params.commentId, req.user._id, done)
+    Comment.downVote(req.params.commentId, req.user._id)
+    .then( res.json )
+    .catch( next );
 };

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -7,6 +7,7 @@ var exp = module.exports;
 
 exp.findByQAId = function(req, res, next) {
 	findQuery = [];
+	//I wholeheartedly apologize for the following godawful mess and will fix soon :)
 	propertiesToFind ['questionId', 'answerId'];
 	propertiesToFind.foreach(function(property) {
 		var valueToPush;
@@ -17,9 +18,7 @@ exp.findByQAId = function(req, res, next) {
 		findQuery.push({underscoreProperty: valueToPush});
 	});
 
-	Comment.find({$and: findQuery})
-	.then( res.json )
-	.catch( next );
+	return Comment.find({$and: findQuery});
 };
 
 exp.addByQAId = function(req, res, next) {
@@ -29,44 +28,32 @@ exp.addByQAId = function(req, res, next) {
 	comment.message = req.body.message;
 	comment.parent  = new ObjectId(req.params.parentId);
 
-	comment.save()
-	.then( res.json )
-	.catch ( next );
+	return comment.save();
 };
 
 exp.findByCommentId = function(req, res, next) {
-	Comment.findById(req.params.commentId)
-	.then( res.json )
-	.catch( next );
+	return Comment.findById(req.params.commentId)
 }
 
 exp.updateComment = function(req, res, next) {
-	Comment.findById(req.params.commentId)
+	return Comment.findById(req.params.commentId)
 	.then( function(comment) {
 		comment.message = req.body.message;
 		return comment.save();
 	})
-	.then( res.json )
-	.catch( next );
 }
 
 exp.deleteComment = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
 
-    Comment.setAsDeleted(req.params.commentId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Comment.setAsDeleted(req.params.commentId, req.user._id)
 };
 
 exp.upVoteComment = function(req, res, next) {
-    Comment.upVote(req.params.commentId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Comment.upVote(req.params.commentId, req.user._id);
 };
 
 exp.downVoteComment = function(req, res, next) {
-    Comment.downVote(req.params.commentId, req.user._id)
-    .then( res.json )
-    .catch( next );
+    return Comment.downVote(req.params.commentId, req.user._id);
 };

--- a/Server/controllers/groups.js
+++ b/Server/controllers/groups.js
@@ -5,31 +5,16 @@ var exp = module.exports;
 
 
 exp.findById = function (req, res, next) {
-
-  var getGroup = Group.findOne(
-    { '_id': new ObjectId(req.params.groupId) }
-  ).exec();
-
-  getGroup.addBack( function (err, group) {
-    if (err) return next(err);
-    res.json(group);
-  });
-
+  Group.findById(req.params.groupId)
+  .then( res.json )
+  .catch( next );
 };
-
 
 exp.findAll = function (req, res, next) {
-
   Group.find()
-  .then(function(groups) {
-    res.mjson(groups);
-  })
-  .catch(function(error) {
-    next(error);
-  });
-
+  .then( res.mjson )
+  .catch( next );
 };
-
 
 exp.addGroup = function (req, res, next) {
 
@@ -37,18 +22,12 @@ exp.addGroup = function (req, res, next) {
 
   var group = new Group();
   
-  group.name = req.body.name;
+  group.name   = req.body.name;
+  group.topics = req.body.topics;
 
-  var topics = req.body.topics;
-  
-  for(var i in topics) {
-    group.topics.push(ObjectId(topics[i]))
-  }
-  
-  group.save( function (err, group) {
-    if (err) return next(err);
-    res.json(group)
-  });
+  group.save()
+  .then( res.json )
+  .error( next );
 
 };
 
@@ -63,22 +42,21 @@ exp.updateTopics = function (req, res, next) {
     { '_id': req.params.groupId }
   ).exec();
 
-  updateTopics.addBack( function (err, group) {
-    if (err) return next(err);
-
-    if (group) { 
-      
+  Group.findById(req.params.groupId)
+  .then( function(group) {
+    if (group) {
       for (var i in topics) {
         if (group.topics.indexOf(topics[i]) === -1) {
-          group.topics.push(ObjectId(topics[i]));
+          group.topics.push(topics[i]);
         }  
       }
-
-      group.save();
+      return group.save();
+    } else {
+      return group;
     }
-
-    res.json(group);
-  });
+  })
+  .then( res.json )
+  .catch( next);
 
 };
 
@@ -90,11 +68,8 @@ exp.deleteGroup = function (req, res, next) {
   var deleteGroup = Group.update(
     { '_id': req.params.groupId },
     { $set: { 'deleted': true } }
-  ).exec();
-
-  deleteGroup.addBack( function (err, updated, raw) {
-    if (err) return next(err);
-    res.json(raw);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 
 };

--- a/Server/controllers/groups.js
+++ b/Server/controllers/groups.js
@@ -5,15 +5,11 @@ var exp = module.exports;
 
 
 exp.findById = function (req, res, next) {
-  Group.findById(req.params.groupId)
-  .then( res.json )
-  .catch( next );
+  return Group.findById(req.params.groupId);
 };
 
 exp.findAll = function (req, res, next) {
-  Group.find()
-  .then( res.mjson )
-  .catch( next );
+  return Group.find();
 };
 
 exp.addGroup = function (req, res, next) {
@@ -25,9 +21,7 @@ exp.addGroup = function (req, res, next) {
   group.name   = req.body.name;
   group.topics = req.body.topics;
 
-  group.save()
-  .then( res.json )
-  .error( next );
+  return group.save();
 
 };
 
@@ -38,11 +32,7 @@ exp.updateTopics = function (req, res, next) {
 
   var topics = req.body.topics;
 
-  var updateTopics = Group.findOne(
-    { '_id': req.params.groupId }
-  ).exec();
-
-  Group.findById(req.params.groupId)
+  return Group.findById(req.params.groupId)
   .then( function(group) {
     if (group) {
       for (var i in topics) {
@@ -54,9 +44,7 @@ exp.updateTopics = function (req, res, next) {
     } else {
       return group;
     }
-  })
-  .then( res.json )
-  .catch( next);
+  });
 
 };
 
@@ -65,11 +53,9 @@ exp.deleteGroup = function (req, res, next) {
   
   // TODO add auth info ensure only mods and admin can delete
 
-  var deleteGroup = Group.update(
+  return Group.update(
     { '_id': req.params.groupId },
     { $set: { 'deleted': true } }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 
 };

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -6,24 +6,15 @@ var exp = module.exports;
 
 exp.findByQuestionId = function (req, res, next) {
   Question.findById(req.params.questionId)
-  .then(
-      function(result) {
-        return res.mjson(result);
-      },
-      function(error) {
-        return next(error)
-      }
-  );
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
   Question.find()
-  .populate('author', 'username')
-  .exec( function (err, questions) {
-    if(err) return next(err);
-    res.mjson(questions)
-  });
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.addQuestion = function (req, res, next) {
@@ -37,24 +28,15 @@ exp.addQuestion = function (req, res, next) {
   question.message      = req.body.message;
   question.group        = req.body.group;
   question.topics       = req.body.topics;
-  //question.images.      push(req.body.imageUrl);
-  //question.videos.      push(req.body.videoUrl);
-  //question.code.        push(req.body.code);
   question.upVotes.     push(req.user._id);
 
   question.save()
-  .then(function(question) {
-    res.json(question);
-  })
-  .catch(function(error) {
-    console.error(error);
-    next(error);
-  })
+  .then( res.json )
+  .catch( next );
 };
 
 exp.updateQuestion = function (req, res, next) {
 // TODO add auth info ensure only user and admin can update
-	console.log(req.body);
   Question.findById(req.params.questionId)
   .then(function(question) {
     question.message = req.body.message;
@@ -64,40 +46,26 @@ exp.updateQuestion = function (req, res, next) {
     question.dateModified = new Date();
     return question.save();
   })
-  .then(function(updatedQuestion) {
-    res.mjson(updatedQuestion);
-  })
-  .catch( function(error) {
-    console.error(error);
-    return next(error);
-  });
+  .then( res.mjson )
+  .catch( next );
 };
 
 exp.deleteQuestion = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-    Question.setAsDeleted(req.params.questionId, req.user._id).then(
-      res.mjson,
-      next
-    );
+    Question.setAsDeleted(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.upVoteQuestion = function(req, res, next) {
-
-    var done = function (err, upVoted) {
-        if(err) return next(err);
-        res.mjson(upVoted);
-    }
-
-    Question.upVote(req.params.questionId, req.user._id, done)
+    Question.upVote(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };
 
 exp.downVoteQuestion = function(req, res, next) {
-
-    var done = function (err, downVoted) {
-        if(err) return next(err);
-        res.mjson(downVoted);
-    }
-
-    Question.downVote(req.params.questionId, req.user._id, done)
+    Question.downVote(req.params.questionId, req.user._id)
+    .then( res.mjson )
+    .catch( next );
 };

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -10,7 +10,11 @@ exp.findByQuestionId = function (req, res, next) {
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
-  return Question.find()
+  if (req.params.groupID) {
+    return Question.find({'group': req.params.groupID});
+  } else {
+    return Question.find()
+  }
 };
 
 exp.addQuestion = function (req, res, next) {

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -5,16 +5,12 @@ var Question = require('../models/question');
 var exp = module.exports;
 
 exp.findByQuestionId = function (req, res, next) {
-  Question.findById(req.params.questionId)
-  .then( res.mjson )
-  .catch( next );
+  return Question.findById(req.params.questionId)
 };
 
 exp.nextTenQuestions = function (req, res, next) {
   // TODO This will be replaced with the feed soon...
-  Question.find()
-  .then( res.mjson )
-  .catch( next );
+  return Question.find()
 };
 
 exp.addQuestion = function (req, res, next) {
@@ -30,14 +26,12 @@ exp.addQuestion = function (req, res, next) {
   question.topics       = req.body.topics;
   question.upVotes.     push(req.user._id);
 
-  question.save()
-  .then( res.json )
-  .catch( next );
+  return question.save()
 };
 
 exp.updateQuestion = function (req, res, next) {
 // TODO add auth info ensure only user and admin can update
-  Question.findById(req.params.questionId)
+  return Question.findById(req.params.questionId)
   .then(function(question) {
     question.message = req.body.message;
     question.title = req.body.title;
@@ -46,26 +40,18 @@ exp.updateQuestion = function (req, res, next) {
     question.dateModified = new Date();
     return question.save();
   })
-  .then( res.mjson )
-  .catch( next );
 };
 
 exp.deleteQuestion = function(req, res, next) {
   
     // TODO add auth info ensure only creator, mods and admin can delete
-    Question.setAsDeleted(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.setAsDeleted(req.params.questionId, req.user._id)
 };
 
 exp.upVoteQuestion = function(req, res, next) {
-    Question.upVote(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.upVote(req.params.questionId, req.user._id)
 };
 
 exp.downVoteQuestion = function(req, res, next) {
-    Question.downVote(req.params.questionId, req.user._id)
-    .then( res.mjson )
-    .catch( next );
+    return Question.downVote(req.params.questionId, req.user._id)
 };

--- a/Server/controllers/topics.js
+++ b/Server/controllers/topics.js
@@ -5,9 +5,7 @@ var exp = module.exports;
 
 exp.findById = function (req, res, next) {
 
-  Topic.findById(req.params.topicId)
-  .then( res.json )
-  .catch( next );
+  return Topic.findById(req.params.topicId);
 
 };
 
@@ -21,9 +19,7 @@ exp.findByName = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  Topic.find()
-  .then( res.mjson )
-  .catch( next );
+  return Topic.find();
 };
 
 
@@ -35,9 +31,7 @@ exp.addTopic = function (req, res, next) {
   // TODO set case of topic (all lower?)
   topic.name = req.body.name;
 
-  topic.save()
-  .then( res.json )
-  .catch( next );
+  return topic.save();
 
 };
 
@@ -46,11 +40,9 @@ exp.deleteTopic = function (req, res, next) {
   
   // TODO check if user is admin
 
-  Topic.update(
+  return Topic.update(
     { '_id': req.params.topicId },
     { $set: { 'deleted': true } }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 
 };

--- a/Server/controllers/topics.js
+++ b/Server/controllers/topics.js
@@ -5,15 +5,9 @@ var exp = module.exports;
 
 exp.findById = function (req, res, next) {
 
-  Topic.findOne(
-    { '_id': new ObjectId(req.params.topicId) }
-  )
-  .then( function (topic) {
-    res.json(topic);
-  })
-  .catch(function(error) {
-    return next(error)
-  });
+  Topic.findById(req.params.topicId)
+  .then( res.json )
+  .catch( next );
 
 };
 
@@ -27,14 +21,9 @@ exp.findByName = function (req, res, next) {
 
 exp.findAll = function (req, res, next) {
 
-  Topic.find().exec()
-  .then( function (topics) {
-    res.mjson(topics);
-  })
-  .catch(function(error) {
-    return next(error)
-  });
-
+  Topic.find()
+  .then( res.mjson )
+  .catch( next );
 };
 
 
@@ -46,10 +35,9 @@ exp.addTopic = function (req, res, next) {
   // TODO set case of topic (all lower?)
   topic.name = req.body.name;
 
-  topic.save( function (err, topic) {
-    if (err) return next(err);
-    res.json(topic)
-  });
+  topic.save()
+  .then( res.json )
+  .catch( next );
 
 };
 
@@ -58,14 +46,11 @@ exp.deleteTopic = function (req, res, next) {
   
   // TODO check if user is admin
 
-  var deleteTopic = Topic.update(
+  Topic.update(
     { '_id': req.params.topicId },
     { $set: { 'deleted': true } }
-  ).exec();
-
-  deleteTopic.addBack( function (err, updated, raw) {
-    if (err) return next(err);
-    res.json(raw);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 
 };

--- a/Server/controllers/users.js
+++ b/Server/controllers/users.js
@@ -4,15 +4,11 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findUserById = function (req, res, next) {
-  User.findById(req.params.userId)
-  .then( res.json )
-  .catch( next );
+  return User.findById(req.params.userId);
 };
 
 exp.findUserByUsername = function (req, res, next) {
-  User.findOne(
+  return User.findOne(
     { 'local.username': req.body.username }
-  )
-  .then( res.json )
-  .catch( next );
+  );
 };

--- a/Server/controllers/users.js
+++ b/Server/controllers/users.js
@@ -4,23 +4,15 @@ var ObjectId = require('mongoose').Types.ObjectId;
 var exp = module.exports;
 
 exp.findUserById = function (req, res, next) {
-  var getUser = User.findOne(
-    { '_id': new ObjectId(req.params.userId) }
-  ).exec();
-
-  getUser.addBack( function (err, user) {
-    if (err) return next(err);
-    res.json(user);
-  });
+  User.findById(req.params.userId)
+  .then( res.json )
+  .catch( next );
 };
 
 exp.findUserByUsername = function (req, res, next) {
-  var getUser = User.findOne(
+  User.findOne(
     { 'local.username': req.body.username }
-  ).exec();
-
-  getUser.addBack( function (err, user) {
-    if (err) return next(err);
-    res.json(user);
-  });
+  )
+  .then( res.json )
+  .catch( next );
 };

--- a/Server/models/comment.js
+++ b/Server/models/comment.js
@@ -11,7 +11,6 @@ var commentSchema = new contentMethods.BaseContentSchema({
 var emitChanged = function(comment) {
 	contentMethods.BaseContent.findById(this.parent)
 	   .then(function(parent) {
-	   		console.log(parent);
 			socketio.io.emit('contentChanged', {'_id': parent._id, 'comments':parent.comments});
 	   }, function(error) {
 	   		console.log(error);

--- a/Server/models/common/contentMethods.js
+++ b/Server/models/common/contentMethods.js
@@ -45,7 +45,7 @@ var BaseContentSchema = function() {
 	mongoose.Schema.apply(this, arguments);
 
 	this.add({
-	    author:         { type: ObjectId, ref: 'User', required: true, autopopulate: {select: 'username displayName'} },
+	    author:         { type: ObjectId, ref: 'User', required: true, autopopulate: {select: 'username displayName', options: {lean: true}} },
 	    authorName:     { type: String, required: false }, 
 	    anonymous:      { type: Boolean, default: false },
 	    message:        { type: String, required: true },

--- a/Server/models/common/contentMethods.js
+++ b/Server/models/common/contentMethods.js
@@ -8,26 +8,27 @@ var ObjectId 		= require('mongoose').Schema.Types.ObjectId;
 
 var autoPopulate 	= require('mongoose-autopopulate');
 
-var upVote = function (contentId, userId, cb) {
+var upVote = function (contentId, userId) {
 	return this.update({'_id': contentId},
 		{
 			$pull: {'downVotes': userId},
 			$addToSet: {'upVotes': userId}
-		}).exec(cb);
+		});
 }
 
-var downVote = function (contentId, userId, cb) {
+var downVote = function (contentId, userId) {
 	return this.update({'_id': contentId},
 		{	
 			$pull: {'upVotes': userId},
 			$addToSet: {'downVotes': userId}
-		}).exec(cb);
+		});
 }
 
-var removeVotes = function (contentId, userId, cb) {
+var removeVotes = function (contentId, userId) {
 	return this.update({'_id': contentId},
-		{$pull: {'upVotes': userId, 'downVotes': userId}})
-	.exec(cb);
+		{
+			$pull: {'upVotes': userId, 'downVotes': userId}
+		});
 }
 
 var setAsDeleted = function (contentId, userId) {

--- a/Server/models/question.js
+++ b/Server/models/question.js
@@ -13,7 +13,7 @@ var autoPopulate 	= require('mongoose-autopopulate');
 var questionSchema = new contentMethods.BaseContentSchema({
     title:          { type: String, required: true },
     topics:         [{ type: String, ref: 'Topic' }],
-    group:          { type: String, ref: 'Group', required: false }, //TODO: SET REQUIRED TO TRUE!!
+    group:          { type: String, required: false }, //TODO: SET REQUIRED TO TRUE!!
     answers:        {
     					type: Array,
     					schema: objectId, ref: 'Answer',

--- a/Server/models/user.js
+++ b/Server/models/user.js
@@ -5,27 +5,28 @@ var Group   = require('./group');
 
 // Schema definition
 var userSchema = mongoose.Schema({
-    username:       String,
-    password:       String,
-    authcate:       String,
-    email:          String,
-    type:           String,
-    personalTitleFull: String,
-    givenNames:     [String],
-    surname:        String,
-    displayName: String,
-    dateCreated:    { type: Date, default: Date.now },
-    dateModified:   { type: Date, default: null },
-    subscriptions:  [String],
-    enrolments:    [String],
-    isAdmin:        { type: Boolean, default: false },
-    moderatorOf:    [{ type: objectId, ref: 'Group' }]
+    username:           String,
+    password:           String,
+    authcate:           String,
+    email:              String,
+    type:               String,
+    personalTitleFulL:  String,
+    givenNames:         [String],
+    surname:            String,
+    displayName:        String,
+    dateCreated:        { type: Date, default: Date.now },
+    dateModified:       { type: Date, default: null },
+    subscriptions:      [String],
+    enrolments:         [String],
+    isAdmin:            { type: Boolean, default: false },
+    moderatorOf:        [{ type: objectId, ref: 'Group' }]
 })
 
 // Indexes
 userSchema.index({ subscriptions: 1 });
 userSchema.path('username').index({text : true});
 userSchema.path('authcate').index({text : true});
+
 
 //TODO Make the following methods asynch
 // generating a hash
@@ -42,6 +43,7 @@ userSchema.methods.validPassword = function(password) {
     }
     return bcrypt.compareSync(password, this.password);
 };
+
 
 userSchema.virtual('firstName').get(function() { try { return this.givenNames[0] } catch (e) { return '' } });
 
@@ -65,9 +67,6 @@ userSchema.methods.generateDisplayName = function() {
                 break;
             default:
                 var e =  new Error('old account with no type!');
-                console.error(e);
-                console.trace(e);
-                console.log(this);
                 throw e;
                 break;
         }
@@ -87,8 +86,6 @@ userSchema.virtual('personalTitle').get(function() {
     }
 });
 
-userSchema.set('toJSON', {virtuals: true, getters: true});
-userSchema.set('toObject', {virtuals: true, getters: true});
 
 userSchema.methods.configureFromAuthcate = function(authcateUserName) {
     var ldap = require('../services/ldapClient.js');
@@ -153,6 +150,10 @@ userSchema.methods.configureFromAuthcate = function(authcateUserName) {
             return error;
         });
 }
+
+
+userSchema.set('toJSON', {virtuals: true, getters: true});
+userSchema.set('toObject', {virtuals: true, getters: true});
 
 
 module.exports = mongoose.model('User', userSchema);

--- a/Server/models/user.js
+++ b/Server/models/user.js
@@ -10,8 +10,8 @@ var userSchema = mongoose.Schema({
     email:          String,
     dateCreated:    { type: Date, default: Date.now },
     dateModified:   { type: Date, default: null },
-    subscriptions:  [{ type: objectId, active: Boolean }],
-    enrollments:    [{ type: objectId, active: Boolean }],
+    subscriptions:  [String],
+    enrollments:    [String],
     isAdmin:        { type: Boolean, default: false },
     moderatorOf:    [{ type: objectId, ref: 'Group' }]
 })

--- a/Server/models/user.js
+++ b/Server/models/user.js
@@ -11,7 +11,7 @@ var userSchema = mongoose.Schema({
     dateCreated:    { type: Date, default: Date.now },
     dateModified:   { type: Date, default: null },
     subscriptions:  [String],
-    enrollments:    [String],
+    enrolments:    [String],
     isAdmin:        { type: Boolean, default: false },
     moderatorOf:    [{ type: objectId, ref: 'Group' }]
 })

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -73,6 +73,7 @@ promisedRouter.get('/user/:username', usersCtrl.findUserByUsername);
 // Question Routes
 promisedRouter.post('/questions', questionsCtrl.addQuestion);
 promisedRouter.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
+promisedRouter.get('/questions/tenMore/:groupID/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
 promisedRouter.get('/questions/:questionId', questionsCtrl.findByQuestionId);
 promisedRouter.put('/questions/:questionId', questionsCtrl.updateQuestion);
 promisedRouter.delete('/questions/:questionId', questionsCtrl.deleteQuestion);

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -25,52 +25,90 @@ function authWrite(req, res, next) {
 	}
 }
 
+// call this with a route controller that returns a promise, for fun and profit.
+// function getQuestions(req, res, next) {
+//   Question.find()
+//   .then( function(q) { res.json(q) } )
+//   .catch( function(error) { next(error) }) ;
+// }
+//
+// is equivalent to
+// function getQuestionSimple(req) {
+//   return Question.find();
+// }
+//
+// jsonRoute(getQuestionsSimple);
+
+
+function jsonRoute(jsonPromise) {
+	return function(req, res, next) {
+		jsonPromise(req, res, next)
+		.then(function(promiseResult) {
+			res.mjson(promiseResult);
+		})
+		.catch( function(error) {
+			console.log(error);
+			next(error)
+		});
+	}
+}
+
+var promisedRouter = {};
+
+//now promisedRouter.get('/route', ctrl.doSomething)
+//    == router.get('/route', jsonRoute(ctrl.doSomething));
+['get','post','put','delete','patch'].forEach(function(action) {
+	promisedRouter[action] = function(route, jsonPromise) {
+		return router[action](route, jsonRoute(jsonPromise));
+	}
+});
+
 // All API routes require auth
 router.use(authWrite)
 
 // User Routes
-router.get('/user/:userId', usersCtrl.findUserById);
-router.get('/user/:username', usersCtrl.findUserByUsername);
+promisedRouter.get('/user/:userId', usersCtrl.findUserById);
+promisedRouter.get('/user/:username', usersCtrl.findUserByUsername);
 
 // Question Routes
-router.post('/questions', questionsCtrl.addQuestion);
-router.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
-router.get('/questions/:questionId', questionsCtrl.findByQuestionId);
-router.put('/questions/:questionId', questionsCtrl.updateQuestion);
-router.delete('/questions/:questionId', questionsCtrl.deleteQuestion);
-router.put('/questions/upvote/:questionId', questionsCtrl.upVoteQuestion);
-router.put('/questions/downvote/:questionId', questionsCtrl.downVoteQuestion);
+promisedRouter.post('/questions', questionsCtrl.addQuestion);
+promisedRouter.get('/questions/tenMore/:requestNumber', questionsCtrl.nextTenQuestions); // TODO Replace this with feed
+promisedRouter.get('/questions/:questionId', questionsCtrl.findByQuestionId);
+promisedRouter.put('/questions/:questionId', questionsCtrl.updateQuestion);
+promisedRouter.delete('/questions/:questionId', questionsCtrl.deleteQuestion);
+promisedRouter.put('/questions/upvote/:questionId', questionsCtrl.upVoteQuestion);
+promisedRouter.put('/questions/downvote/:questionId', questionsCtrl.downVoteQuestion);
 
 // Answer Routes
-router.get('/answers/:questionId', answersCtrl.findByQuestionId);
-router.post('/answers/:questionId', answersCtrl.addByQuestionId);
-router.delete('/answers/:answerId', answersCtrl.deleteAnswer);
-router.put('/answers/upvote/:answerId', answersCtrl.upVoteAnswer);
-router.put('/answers/downvote/:answerId', answersCtrl.downVoteAnswer);
+promisedRouter.get('/answers/:questionId', answersCtrl.findByQuestionId);
+promisedRouter.post('/answers/:questionId', answersCtrl.addByQuestionId);
+promisedRouter.delete('/answers/:answerId', answersCtrl.deleteAnswer);
+promisedRouter.put('/answers/upvote/:answerId', answersCtrl.upVoteAnswer);
+promisedRouter.put('/answers/downvote/:answerId', answersCtrl.downVoteAnswer);
 
 // Comment Routes
 // to be called as comment?questionId=id&answerId=id
-router.get('/comments', commentsCtrl.findByQAId);
-router.get('/comments/:commentId', commentsCtrl.findByCommentId);
-router.post('/comments/:parentId', commentsCtrl.addByQAId);
-router.delete('/comments/:commentId', commentsCtrl.deleteComment);
-router.put('/comments/:commentId', commentsCtrl.updateComment);
-router.put('/comments/upvote/:commentId', commentsCtrl.upVoteComment);
-router.put('/comments/downvote/:commentId', commentsCtrl.downVoteComment);
+promisedRouter.get('/comments', commentsCtrl.findByQAId);
+promisedRouter.get('/comments/:commentId', commentsCtrl.findByCommentId);
+promisedRouter.post('/comments/:parentId', commentsCtrl.addByQAId);
+promisedRouter.delete('/comments/:commentId', commentsCtrl.deleteComment);
+promisedRouter.put('/comments/:commentId', commentsCtrl.updateComment);
+promisedRouter.put('/comments/upvote/:commentId', commentsCtrl.upVoteComment);
+promisedRouter.put('/comments/downvote/:commentId', commentsCtrl.downVoteComment);
 
 // Group Routes
-router.get('/groups', groupsCtrl.findAll);
-router.post('/groups', groupsCtrl.addGroup);
-router.get('/groups/:groupId', groupsCtrl.findById);
-router.put('/groups/:groupId', groupsCtrl.updateTopics);
-router.delete('/groups/:groupId', groupsCtrl.deleteGroup);
+promisedRouter.get('/groups', groupsCtrl.findAll);
+promisedRouter.post('/groups', groupsCtrl.addGroup);
+promisedRouter.get('/groups/:groupId', groupsCtrl.findById);
+promisedRouter.put('/groups/:groupId', groupsCtrl.updateTopics);
+promisedRouter.delete('/groups/:groupId', groupsCtrl.deleteGroup);
 
 // Topic Routes
-router.get('/topics', topicsCtrl.findAll);
-router.post('/topics', topicsCtrl.addTopic);
-router.get('/topics/:topicId', topicsCtrl.findById);
-router.get('/topics/name/:topicName', topicsCtrl.findByName);
-router.delete('/topics/:topicId', topicsCtrl.deleteTopic);
+promisedRouter.get('/topics', topicsCtrl.findAll);
+promisedRouter.post('/topics', topicsCtrl.addTopic);
+promisedRouter.get('/topics/:topicId', topicsCtrl.findById);
+promisedRouter.get('/topics/name/:topicName', topicsCtrl.findByName);
+promisedRouter.delete('/topics/:topicId', topicsCtrl.deleteTopic);
 
 
 module.exports = router;

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -47,8 +47,8 @@ function jsonRoute(jsonPromise) {
 			res.mjson(promiseResult);
 		})
 		.catch( function(error) {
-			console.log(error);
-			next(error)
+			console.error(error.stack);
+			next(error);
 		});
 	}
 }

--- a/Server/server.js
+++ b/Server/server.js
@@ -131,7 +131,7 @@ require(here('/config/socketio'))(server);
 if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
-    res.render('error', {
+    res.json({
       message: err.message,
       error: err
     });
@@ -142,7 +142,7 @@ if (app.get('env') === 'development') {
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
-  res.render('error', {
+  res.json({
     message: err.message,
     error: {}
   });


### PR DESCRIPTION
Change the user schema to use
```js
...
    manualSubscriptions: {
        groups:         [{ type: String, ref: 'Group'}], 
        topics:         [{ type: String, ref: 'Topic'}],
    },
    authcateSubscriptions: {
        groups:         [{ type: String, ref: 'Group'}], 
        topics:         [{ type: String, ref: 'Topic'}],
    },
...
userSchema.virtual('subscriptions.groups').get(function() {
    return this.manualSubscriptions.groups.concat(
                this.authcateSubscriptions.groups
            );
});
userSchema.virtual('subscriptions.topics').get(function() {
    return this.manualSubscriptions.topics.concat(
                this.authcateSubscriptions.topics
            );
});
```
so we can easily track which of the user's interests are self-specified and which are being scraped from ldap. update Client to use the new schema.

Also change the error handling slightly -- now we return something in JSON instead of rendering a page, so our Client controllers can (in future) display this message to the user. Error stack traces are now printed to the console.