### PR TITLE
More fun

### DIFF
--- a/Client/common/components/EditContentForm/editContentForm.js
+++ b/Client/common/components/EditContentForm/editContentForm.js
@@ -94,19 +94,18 @@ var editContentFormController = function($scope, baseContentService, groupServic
     editContentFormController.prototype.saveFunction = function() {};
 
     editContentFormController.prototype.save = function() {
+        this.sendError = null;
         return  this.saveFunction()
-                    .then(
-                        function (newContent) {
-                            console.log('add succeeded');
-                            if (this.$scope.onSubmit) {
-                                this.$scope.onSubmit({'newContent': newContent});
-                            }
-                        }.bind(this),
-                        function (error) {
-                            console.log('add error');
-                            this.status = 'Unable to add question: ' + error.message;
-                        }.bind(this)
-                    );
+                    .then( function (newContent) {
+                        console.log('add succeeded');
+                        if (this.$scope.onSubmit) {
+                            this.$scope.onSubmit({'newContent': newContent});
+                        }
+                    }.bind(this) )
+                    .catch( function (error) {
+                        console.log('add error');
+                        this.sendError = error;
+                    }.bind(this) );
     }
 
     editContentFormController.prototype.edit = function() {

--- a/Client/common/components/EditContentForm/editContentFormTemplate.html
+++ b/Client/common/components/EditContentForm/editContentFormTemplate.html
@@ -57,7 +57,7 @@
 
 
 </md-input-container>
-<kusema-server-message message="c.sendError" messagePrefix="Couldn't post"></kusema-server-message>
+<kusema-server-message message="c.sendError" message-prefix="Couldn't post"></kusema-server-message>
 <div class="md-actions" layout="row">
 	<md-button type="button" ng-click="onCancel()">Cancel</md-button>
 	<md-button type="submit">{{c.actionText}} {{c.contentType}}</md-button>

--- a/Client/common/components/EditContentForm/editContentFormTemplate.html
+++ b/Client/common/components/EditContentForm/editContentFormTemplate.html
@@ -57,7 +57,11 @@
 
 
 </md-input-container>
-<kusema-server-message message="c.sendError" message-prefix="Couldn't post"></kusema-server-message>
+<kusema-server-message
+	message="c.sendError"
+	message-prefix="Couldn't post"
+	class="antiPad"
+	></kusema-server-message>
 <div class="md-actions" layout="row">
 	<md-button type="button" ng-click="onCancel()">Cancel</md-button>
 	<md-button type="submit">{{c.actionText}} {{c.contentType}}</md-button>

--- a/Client/common/components/EditContentForm/editContentFormTemplate.html
+++ b/Client/common/components/EditContentForm/editContentFormTemplate.html
@@ -57,6 +57,7 @@
 
 
 </md-input-container>
+<kusema-server-message message="c.sendError" messagePrefix="Couldn't post"></kusema-server-message>
 <div class="md-actions" layout="row">
 	<md-button type="button" ng-click="onCancel()">Cancel</md-button>
 	<md-button type="submit">{{c.actionText}} {{c.contentType}}</md-button>

--- a/Client/common/components/ServerMessage/serverMessage.css
+++ b/Client/common/components/ServerMessage/serverMessage.css
@@ -9,3 +9,8 @@
 kusema-server-message {
 	display: block;
 }
+
+kusema-server-message.antiPad {
+	margin-left: -8px;
+	margin-right: -8px;
+}

--- a/Client/common/components/ServerMessage/serverMessage.css
+++ b/Client/common/components/ServerMessage/serverMessage.css
@@ -10,6 +10,10 @@ kusema-server-message {
 	display: block;
 }
 
+md-card kusema-server-message.antiPad {
+	margin-left: -16px;
+	margin-right: -16px;
+}
 kusema-server-message.antiPad {
 	margin-left: -8px;
 	margin-right: -8px;

--- a/Client/common/components/ServerMessage/serverMessage.css
+++ b/Client/common/components/ServerMessage/serverMessage.css
@@ -1,0 +1,11 @@
+.serverMessage {
+	padding: 16px 0px;
+	background: #FF5252;
+	color: white;
+	text-align: center;
+
+}
+
+kusema-server-message {
+	display: block;
+}

--- a/Client/common/components/ServerMessage/serverMessage.js
+++ b/Client/common/components/ServerMessage/serverMessage.js
@@ -1,0 +1,50 @@
+var serverMessageDirective = function() {
+	return {
+		scope: {},
+		bindToController: {
+			'message': '='
+		},
+		templateUrl: 'common/components/ServerMessage/serverMessageTemplate.html',
+		controller: 'kusemaServerMessageController',
+		controllerAs: 'c',
+		css: 'common/components/ServerMessage/serverMessage.css'
+	};
+}
+
+
+var serverMessageController = function() {
+	console.log('message!!');
+	this.setMessageProperties();
+}
+
+serverMessageController.prototype = Object.create(Object.prototype, {
+	'_message': {writable: true, enumerable: false, value: null},
+	'message': {
+		get: function() {
+			return this._message;
+		},
+		set: function(newMessage) {
+			console.log('setting message');
+			this._message = newMessage;
+			this.setMessageProperties();
+		}
+	},
+	'type': {writable: true, enumerable: false, value: ''},
+	'messageText': {writable: true, enumerable: false, value: ''},
+});
+
+serverMessageController.prototype.setMessageProperties = function() {
+	if (!this.message) {
+		console.log('no error');
+		delete this.type;
+		delete this.messageText;
+	} else {
+		console.log('showing error');
+		this.type = this.message.type || 'error';
+		this.messageText = (this.message.data && this.message.data.message) || this.message.data || 'Server Problem';
+	}
+}
+
+kusema.addModule('components.serverMessage')
+      .directive('kusemaServerMessage', serverMessageDirective)
+      .controller('kusemaServerMessageController', serverMessageController);

--- a/Client/common/components/ServerMessage/serverMessage.js
+++ b/Client/common/components/ServerMessage/serverMessage.js
@@ -41,7 +41,11 @@ serverMessageController.prototype.setMessageProperties = function() {
 	} else {
 		console.log('showing error');
 		this.type = this.message.type || 'error';
-		this.messageText = (this.message.data && this.message.data.message) || this.message.data || 'Server Problem';
+		this.messageText = (this.message.data && this.message.data.message)
+							|| this.message.data
+							|| this.message.message
+							|| this.message
+							|| 'Server Problem';
 	}
 }
 

--- a/Client/common/components/ServerMessage/serverMessage.js
+++ b/Client/common/components/ServerMessage/serverMessage.js
@@ -3,7 +3,7 @@ var serverMessageDirective = function() {
 		scope: {},
 		bindToController: {
 			'message': '=',
-			'messagePrefix': '='
+			'messagePrefix': '@'
 		},
 		templateUrl: 'common/components/ServerMessage/serverMessageTemplate.html',
 		controller: 'kusemaServerMessageController',

--- a/Client/common/components/ServerMessage/serverMessage.js
+++ b/Client/common/components/ServerMessage/serverMessage.js
@@ -2,7 +2,8 @@ var serverMessageDirective = function() {
 	return {
 		scope: {},
 		bindToController: {
-			'message': '='
+			'message': '=',
+			'messagePrefix': '='
 		},
 		templateUrl: 'common/components/ServerMessage/serverMessageTemplate.html',
 		controller: 'kusemaServerMessageController',
@@ -27,6 +28,13 @@ serverMessageController.prototype = Object.create(Object.prototype, {
 			console.log('setting message');
 			this._message = newMessage;
 			this.setMessageProperties();
+		}
+	},
+	'messagePrefixBind': {
+		get: function() {
+			if (this.messagePrefix) {
+				return this.messagePrefix + ': ';
+			}
 		}
 	},
 	'type': {writable: true, enumerable: false, value: ''},

--- a/Client/common/components/ServerMessage/serverMessageTemplate.html
+++ b/Client/common/components/ServerMessage/serverMessageTemplate.html
@@ -1,1 +1,1 @@
-<div class="serverMessage md-warn {{c.type}}" ng-if="c.message">{{c.messageText}}</div>
+<div class="serverMessage md-warn {{c.type}}" ng-if="c.message">{{c.messagePrefixBind}}{{c.messageText}}</div>

--- a/Client/common/components/ServerMessage/serverMessageTemplate.html
+++ b/Client/common/components/ServerMessage/serverMessageTemplate.html
@@ -1,0 +1,1 @@
+<div class="serverMessage md-warn {{c.type}}" ng-if="c.message">{{c.messageText}}</div>

--- a/Client/common/components/UserMenu/notLoggedInTemplate.html
+++ b/Client/common/components/UserMenu/notLoggedInTemplate.html
@@ -1,6 +1,10 @@
 <md-menu-item><md-button ng-click="c.loginMonash()">Login with Authcate</md-button></md-menu-item>
 <md-menu-divider></md-menu-divider>
 <form style="padding: 0.5em">
+<kusema-server-message
+	message="c.loginMessage"
+	style="margin: 0px -8px;"
+	></kusema-server-message>
 <md-input-container>
 	<label>Username</label>
 	<input name="username" ng-model="c.data.displayName"/>

--- a/Client/common/components/UserMenu/notLoggedInTemplate.html
+++ b/Client/common/components/UserMenu/notLoggedInTemplate.html
@@ -7,7 +7,7 @@
 	></kusema-server-message>
 <md-input-container>
 	<label>Username</label>
-	<input name="username" ng-model="c.data.displayName"/>
+	<input name="username" ng-model="c.data.username"/>
 </md-input-container>
 <md-input-container>
 	<label>Password</label>

--- a/Client/common/components/UserMenu/notLoggedInTemplate.html
+++ b/Client/common/components/UserMenu/notLoggedInTemplate.html
@@ -3,7 +3,7 @@
 <form style="padding: 0.5em">
 <kusema-server-message
 	message="c.loginMessage"
-	style="margin: 0px -8px;"
+	class="antiPad"
 	></kusema-server-message>
 <md-input-container>
 	<label>Username</label>

--- a/Client/common/components/UserMenu/notLoggedInTemplate.html
+++ b/Client/common/components/UserMenu/notLoggedInTemplate.html
@@ -9,8 +9,18 @@
 	<label>Password</label>
 	<input type="password" name="password" ng-model="c.data.password"/>
 </md-input-container>
-<div style="display: flex; flex-direction: row;">
-<md-menu-item><md-button type="submit" ng-click="c.login()">Login Local</md-button></md-menu-item>
-<md-menu-item><md-button type="submit" ng-click="c.register()">Register Local</md-button></md-menu-item>
+
+<div
+	style="display: flex; flex-direction: row;"
+	ng-show="c.loginData.loginState == 0"
+	>
+	<md-menu-item><md-button type="submit" id="loginButton" md-menu-disable-close>Login Local</md-button></md-menu-item>
+	<md-menu-item><md-button type="submit" ng-click="c.register()">Register Local</md-button></md-menu-item>
 </div>
+
+<md-menu-item
+	ng-show="c.loginData.loginState < 0"
+	>
+	<md-button disabled type="button">Wait...</md-button>
+</md-menu-item>
 </form>

--- a/Client/common/components/UserMenu/userMenu.js
+++ b/Client/common/components/UserMenu/userMenu.js
@@ -24,7 +24,10 @@ var userMenuController = function($scope, $timeout, $mdMenu, $q, loginService) {
 		this.$timeout(function() { 
 			// we need to do this instead of ngClick because if we can't cancel
 			// the event, we can't stop the menu closing.
-			document.getElementById('loginButton').addEventListener('click', this.clickLogin.bind(this), true)
+			if (!this.listenerAdded) {
+				document.getElementById('loginButton').addEventListener('click', this.clickLogin.bind(this), true)
+				this.listenerAdded = true;
+			}
 		}.bind(this));
 	}
 	userMenuController.prototype.loginMonash = function() {

--- a/Client/common/components/UserMenu/userMenu.js
+++ b/Client/common/components/UserMenu/userMenu.js
@@ -6,24 +6,46 @@ var userMenuDirective = function() {
 		};
 	};
 //}
-var userMenuController = function($scope, loginService, $mdBottomSheet) {
+var userMenuController = function($scope, $timeout, $mdMenu, $q, loginService) {
 		this.$scope = $scope;
-		this.$mdBottomSheet = $mdBottomSheet;
+		this.$timeout = $timeout;
+		this.$mdMenu = $mdMenu;
+		this.$q = $q;
 		this.originalEvent = null;
 		this.loginService = loginService;
 		this.loginData = loginService.bindables;
 		return this;
 	}
+
 	userMenuController.prototype.openMenu = function(openMenuFunction, event) {
 		this.originalEvent = event;
 		openMenuFunction(event);
+		this.loginMessage = null;
+		this.$timeout(function() { 
+			// we need to do this instead of ngClick because if we can't cancel
+			// the event, we can't stop the menu closing.
+			document.getElementById('loginButton').addEventListener('click', this.clickLogin.bind(this), true)
+		}.bind(this));
 	}
 	userMenuController.prototype.loginMonash = function() {
 		this.loginService.loginMonash();
 	}
+	userMenuController.prototype.clickLogin = function(event) {
+		console.log('clicked Login');
+		event.stopPropagation();
+		this.loginMessage = null;
+		this.login()
+		.then( function() {
+			this.$mdMenu.hide();
+		}.bind(this));
+	}
 	userMenuController.prototype.login = function() {
 		console.log('login');
-		this.loginService.login(this.data.username, this.data.password);
+		return this.loginService.login(this.data.username, this.data.password)
+		.catch(function(e) {
+			this.loginMessage = e;
+			return this.$q.reject(e);
+		}.bind(this));
 	}
 	userMenuController.prototype.register = function() {
 		console.log('register');
@@ -36,7 +58,6 @@ var userMenuController = function($scope, loginService, $mdBottomSheet) {
 		console.log('logout');
 		this.loginService.logout();
 	}
-
 
 
 var userMenuNotLoggedInDirective = function() {
@@ -56,6 +77,6 @@ var userMenuLoggedInDirective = function() {
 
 kusema.addModule('kusema.components.userMenu')
 		.directive('kusemaUserMenu', userMenuDirective)
-		.controller('kusemaUserMenuController', ['$scope', 'loginService', '$mdBottomSheet', userMenuController])
+		.controller('kusemaUserMenuController', ['$scope', '$timeout', '$mdMenu', '$q', 'loginService', userMenuController])
 		.directive('kusemaUserMenuNotLoggedIn', userMenuNotLoggedInDirective)
 		.directive('kusemaUserMenuLoggedIn', userMenuLoggedInDirective);

--- a/Client/common/components/UserMenu/userMenu.js
+++ b/Client/common/components/UserMenu/userMenu.js
@@ -46,6 +46,7 @@ var userMenuController = function($scope, $timeout, $mdMenu, $q, loginService) {
 		console.log('login');
 		return this.loginService.login(this.data.username, this.data.password)
 		.catch(function(e) {
+			console.log('caught');
 			this.loginMessage = e;
 			return this.$q.reject(e);
 		}.bind(this));

--- a/Client/common/components/UserMenu/userMenuTemplate.html
+++ b/Client/common/components/UserMenu/userMenuTemplate.html
@@ -9,20 +9,13 @@
 		<span ng-if="c.loginData.loginState == -2">Logging out...</span>
 		<md-icon md-font-library="material-icons">account_circle</md-icon>
 	</md-button>
-	<md-menu-content width="4">
+	<md-menu-content class="userMenuContent" width="4" style="overflow-x: hidden;">
 			<kusema-user-menu-logged-in
-				ng-if="c.loginData.loginState == 1"
+				ng-show="c.loginData.loginState == 1"
 			></kusema-user-menu-logged-in>
+
 			<kusema-user-menu-not-logged-in
-				ng-if="c.loginData.loginState == 0"
+				ng-show="c.loginData.loginState < 1"
 			></kusema-user-menu-not-logged-in>
-			<md-menu-item ng-if="c.loginData.loginState < 0"><md-button>Wait...</md-button></md-menu-item>
 	</md-menu-content>
 </md-menu>
-
-
-<template id="monashLoginDialog">
-<md-bottom-sheet style="position: fixed; min-height: 80%; display: flex;">
-<iframe src="/account/login_monash" style="flex: 1"></iframe>
-</md-bottom-sheet>
-</template>

--- a/Client/common/services/LoginService.js
+++ b/Client/common/services/LoginService.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var LoginService = function($http, $rootScope, kusemaConfig) {
+var LoginService = function($http, $rootScope, $q, kusemaConfig) {
 		this.$rootScope = $rootScope;
 		this.$http = $http;
+		this.$q = $q;
 		this.kusemaConfig = kusemaConfig;
 		this.bindables = {
 			loginState: 0,
@@ -55,7 +56,7 @@ var LoginService = function($http, $rootScope, kusemaConfig) {
 						}.bind(this))
 						.catch( function(error) {
 							this.bindables.loginState = 0;
-							console.log('login error');
+							return this.$q.reject(error);
 						}.bind(this));
 	};
 	LoginService.prototype.logout = function() {
@@ -90,4 +91,4 @@ var LoginService = function($http, $rootScope, kusemaConfig) {
 	}
 //} loginService
 
-kusema.service('loginService', ['$http', '$rootScope', 'kusemaConfig', LoginService]);
+kusema.service('loginService', ['$http', '$rootScope', '$q', 'kusemaConfig', LoginService]);

--- a/Client/common/services/LoginService.js
+++ b/Client/common/services/LoginService.js
@@ -51,7 +51,7 @@ var LoginService = function($http, $rootScope, $q, kusemaConfig) {
 							{'username': username, 'password': password}
 						)
 						.then( function(response) {
-							console.log('login request done');
+							console.log('logged in as '+response.data.username);
 							return this.checkLogin();
 						}.bind(this))
 						.catch( function(error) {
@@ -64,7 +64,6 @@ var LoginService = function($http, $rootScope, $q, kusemaConfig) {
 		this.bindables.loginState = -2;
 		return logoutRequest.then(
 			function(response) {
-				console.log('logout done');
 				return this.checkLogin();
 			}.bind(this),
 			function(error) {
@@ -80,10 +79,8 @@ var LoginService = function($http, $rootScope, $q, kusemaConfig) {
 		return checkRequest.then(function(response) {
 			if (response.data) {
 				this.bindables.loginState = 1;
-				console.log('we\'re in!');
 			} else {
 				this.bindables.loginState = 0;
-				console.log('we\'re out!');
 			}
 			this.bindables.user = response.data;
 			this.$rootScope.$broadcast('loginChanged');

--- a/Client/common/services/LoginService.js
+++ b/Client/common/services/LoginService.js
@@ -54,7 +54,7 @@ var LoginService = function($http, $rootScope, kusemaConfig) {
 							return this.checkLogin();
 						}.bind(this))
 						.catch( function(error) {
-							this.loginState = 0;
+							this.bindables.loginState = 0;
 							console.log('login error');
 						}.bind(this));
 	};

--- a/Client/index.html
+++ b/Client/index.html
@@ -69,6 +69,7 @@
     <script src="common/components/InlineDate/inlineDate.js"></script>
     <script src="common/components/InlineGroup/inlineGroup.js"></script>
     <script src="common/components/Markdown/markdown.js"></script>
+    <script src="common/components/ServerMessage/serverMessage.js"></script>
 
 
 </body>

--- a/Client/index.html
+++ b/Client/index.html
@@ -18,7 +18,7 @@
 
     <ng-include="'checkBrowser.html'"></ng-include="'checkBrowser.html'">
     
-    <md-content id="content" style="position: fixed; width: 100%; height: 100%" ui-view></md-content>
+    <section id="content" style="position: fixed; width: 100%; height: 100%" ui-view></section>
 
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>

--- a/Client/user/kusemaUser.css
+++ b/Client/user/kusemaUser.css
@@ -1,0 +1,3 @@
+kusema-user > md-content {
+	background-color: #fbf9fb;
+}

--- a/Client/user/kusemaUser.js
+++ b/Client/user/kusemaUser.js
@@ -21,9 +21,9 @@ var KusemaUserDirective = function() {
 			action: '='
 		},
 		templateUrl: 'user/kusemaUserTemplate.html',
-		replace: true,
 		controller: 'kusemaUserController',
-		controllerAs: 'c'
+		controllerAs: 'c',
+		css: 'user/kusemaUser.css'
 	};
 };
 

--- a/Client/user/kusemaUserTemplate.html
+++ b/Client/user/kusemaUserTemplate.html
@@ -1,4 +1,4 @@
-<section>
+
 <md-toolbar>
   <div class="md-toolbar-tools">
     <div class="settings-padding" ng-style="{width: $mdMedia('gt-md') ? '300px' : 'auto'}">
@@ -14,7 +14,7 @@
   </div>
 </md-toolbar>
 
-<section layout="row" flex>
+<md-content layout="row" style="height: 100%;" flex>
 
 <md-sidenav class="md-sidenav-left md-whiteframe-z2" md-component-id="group-navigation" md-is-locked-open="$mdMedia('gt-md')" style="width: 300px;">
     <h2 class="md-subhead">Groups</h2>
@@ -28,9 +28,9 @@
     </md-content>
 </md-sidenav>
 
-<md-content style="max-width: 600px; flex-grow: 1; overflow-y: auto;" ui-view></md-content>
+<section class="kusema-centre" style="max-width: 600px; flex-grow: 1;" ui-view></section>
 
-<div style="flex-grow: 0.01" class="layout-spacer"></div>
+<div class="kusema-centre" style="flex-grow: 0.01" class="layout-spacer"></div>
 
 <div  class=" md-whiteframe-z2"style="width: 180px; visibility: visible; padding: 10px; box-sizing: border-box;" hide show-gt-md>
   <h2 class="md-subhead md-accent">Trending</h2>
@@ -45,5 +45,4 @@
   </ul>
 </div>
 
-</section>
-</section>
+</md-content>

--- a/Server/config/passport.js
+++ b/Server/config/passport.js
@@ -62,16 +62,17 @@ module.exports = function(passport, options) {
         // callback with username and password from client side form
         function(req, username, password, done) {
 
-            User.findOne({ 'username' :  username }, function(err, user) {
-                if (err)
-                    return done(err);
+            User.findOne({ 'username' :  username })
+            .then( function(user) {
                 if (!user)
                     return done(null, false, { message: 'Incorrect username.' });
                 if (!user.validPassword(password))
                     return done(null, false, { message: 'Incorrect password.' });
 
-                // username and password matches
                 return done(null, user);
+            })
+            .catch( function(error) {
+                return done(error);
             });
         }
     ));

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -24,6 +24,24 @@ exp.addByQuestionId = function(req, res, next) {
     });
 }
 
+exp.updateAnswer = function(req, res, next) {
+    return Answer.findById(req.params.answerId)
+    .then( function(answer) {
+        console.log(answer);
+        answer.setFromJSON(req.body, req.user._id);
+        return answer.save();
+    })
+    .then( function(answer) {
+        console.log(answer);
+        return answer.populate('author');
+    })
+    .then(function(answer) {
+
+        console.log(answer);
+        return answer;
+    });
+}
+
 exp.deleteAnswer = function(req, res, next) {
     // TODO add auth info ensure only creator, mods and admin can delete
     return Answer.setAsDeleted(req.params.answerId, req.user._id);

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -11,17 +11,15 @@ exp.findByQuestionId = function(req, res, next) {
 };
 
 exp.addByQuestionId = function(req, res, next) {
-    var answer = new Answer();
+    var data = req.body;
+    data.parent = req.params.questionId;
     
-    answer.author       = new ObjectId(req.user._id);
-    answer.anonymous    = req.body.anonymous;
-    answer.message      = req.body.message;
-    answer.question     = new ObjectId(req.params.questionId);
-    answer.upVotes.     push(req.user._id);
+    var answer = new Answer();
+    answer.setFromJSON(data, req.user._id);
 
     return answer.save()
     .then( function(answer) {
-            // if we want our plugins to run, i.e. autopopulation, then we need to run a database find :(
+            // if we want our plugins to run, i.e. autopopulation, then we need to run a db find :(
             return Answer.findById(answer._id)
     });
 }

--- a/Server/controllers/answers.js
+++ b/Server/controllers/answers.js
@@ -12,8 +12,8 @@ exp.findByQuestionId = function(req, res, next) {
 
 exp.addByQuestionId = function(req, res, next) {
     var data = req.body;
-    data.parent = req.params.questionId;
-    
+    data.question = req.params.questionId;
+
     var answer = new Answer();
     answer.setFromJSON(data, req.user._id);
 

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -22,11 +22,11 @@ exp.findByQAId = function(req, res, next) {
 };
 
 exp.addByQAId = function(req, res, next) {
-	var comment = new Comment();
+	var data = req.body;
+	data.parent = req.params.parentId;
 
-	comment.author  = req.user._id;
-	comment.message = req.body.message;
-	comment.parent  = new ObjectId(req.params.parentId);
+	var comment = new Comment();
+	comment.setFromJSON(data, req.user._id);
 
 	return comment.save();
 };
@@ -38,7 +38,7 @@ exp.findByCommentId = function(req, res, next) {
 exp.updateComment = function(req, res, next) {
 	return Comment.findById(req.params.commentId)
 	.then( function(comment) {
-		comment.message = req.body.message;
+		comment.setFromJSON(req.body, req.user._id);
 		return comment.save();
 	})
 }

--- a/Server/controllers/comments.js
+++ b/Server/controllers/comments.js
@@ -28,7 +28,11 @@ exp.addByQAId = function(req, res, next) {
 	var comment = new Comment();
 	comment.setFromJSON(data, req.user._id);
 
-	return comment.save();
+	return comment.save()
+	.then(function(comment) {
+		comment.populate('author');
+		return comment;
+	});
 };
 
 exp.findByCommentId = function(req, res, next) {
@@ -40,7 +44,10 @@ exp.updateComment = function(req, res, next) {
 	.then( function(comment) {
 		comment.setFromJSON(req.body, req.user._id);
 		return comment.save();
-	})
+	}).then( function(comment) {
+		comment.populate('author');
+		return comment;
+	});
 }
 
 exp.deleteComment = function(req, res, next) {

--- a/Server/controllers/questions.js
+++ b/Server/controllers/questions.js
@@ -19,14 +19,7 @@ exp.nextTenQuestions = function (req, res, next) {
 
 exp.addQuestion = function (req, res, next) {
   var question = new Question();
-
-  question.title        = req.body.title;
-  question.author       = req.user._id;
-  question.authorName   = req.body.authorName;
-  question.anonymous    = req.body.anonymous;
-  question.message      = req.body.message;
-  question.group        = req.body.group;
-  question.topics       = req.body.topics;
+  question.setFromJSON(req.body, req.user._id);
   question.upVotes.     push(req.user._id);
 
   return question.save()
@@ -36,10 +29,7 @@ exp.updateQuestion = function (req, res, next) {
 // TODO add auth info ensure only user and admin can update
   return Question.findById(req.params.questionId)
   .then(function(question) {
-    question.message = req.body.message;
-    question.title = req.body.title;
-    question.group        = req.body.group;
-    question.topics        = req.body.topics;
+    question.setFromJSON(req.body, req.user._id);
     question.dateModified = new Date();
     return question.save();
   })

--- a/Server/errors.js
+++ b/Server/errors.js
@@ -1,0 +1,13 @@
+var UnauthorizedError = function(message) {
+	Error.call(this);
+
+	if (message) this.message = message;
+};
+
+UnauthorizedError.prototype = Object.create(Error.prototype, {
+	'message': {writable: true, value: 'You are not allowed to do that'},
+	'name': {writable: true, value: 'UnauthorizedError'},
+	'status': {writable: true, value: 401}
+});
+
+module.exports = {'UnauthorizedError': UnauthorizedError};

--- a/Server/models/answer.js
+++ b/Server/models/answer.js
@@ -1,12 +1,12 @@
 var mongoose        = require('mongoose');
-var objectId        = mongoose.Schema.Types.ObjectId;
+var ObjectId        = mongoose.Schema.Types.ObjectId;
 var Question        = require('../models/question');
 var media           = require('./common/media');
 var contentMethods  = require('./common/contentMethods');
 
 // Schema definition
 var answerSchema = new contentMethods.BaseContentSchema({
-    question:     { type: objectId, ref: 'Question', required: true },
+    question:     { type: ObjectId, ref: 'Question', required: true },
     isAccepted:     { type: Boolean, ref: 'Answer', default: false}
 })
 
@@ -23,6 +23,11 @@ answerSchema.pre('save', function(next) {
 answerSchema.pre('remove', function(next) {
     Question.update({_id: this.question},{$pull:{'answers': this._id}}, next);
 })
+
+answerSchema.methods.setFromJSON = function(data, userId) {
+    this.__proto__.__proto__.setFromJSON.call(this, data, userId);
+    this.question = data.question;
+}
 
 // Validation
 answerSchema.path('question').validate(function (value, respond) {

--- a/Server/models/comment.js
+++ b/Server/models/comment.js
@@ -1,11 +1,11 @@
 var mongoose        = require('mongoose');
-var objectId        = mongoose.Schema.Types.ObjectId;
+var ObjectId        = mongoose.Schema.Types.ObjectId;
 var contentMethods  = require('./common/contentMethods');
 var socketio				= require('../config/socketio');
 
 // Schema definition
 var commentSchema = new contentMethods.BaseContentSchema({
-    parent:     { type: objectId, ref: 'BaseContent', required: true },
+    parent:     { type: ObjectId, ref: 'BaseContent', required: true },
 })
 
 var emitChanged = function(comment) {
@@ -34,6 +34,14 @@ commentSchema.pre('remove', function(next) {
 })
 commentSchema.post('save', emitChanged);
 commentSchema.post('remove', emitChanged);
+
+commentSchema.methods.setFromJSON = function(data, userId) {
+    this.__proto__.__proto__.setFromJSON.call(this, data, userId);
+    //don't allow resetting the comment's parent
+	if (data.parent && !this.parent) {
+			this.parent = data.parent;
+		}
+}
 
 
 module.exports = contentMethods.BaseContent.discriminator('Comment', commentSchema);

--- a/Server/models/common/contentMethods.js
+++ b/Server/models/common/contentMethods.js
@@ -8,6 +8,8 @@ var ObjectId 		= require('mongoose').Schema.Types.ObjectId;
 
 var autoPopulate 	= require('mongoose-autopopulate');
 
+var UnauthorizedError = require('../../errors.js').UnauthorizedError;
+
 var upVote = function (contentId, userId) {
 	return this.update({'_id': contentId},
 		{
@@ -42,7 +44,13 @@ var setAsDeleted = function (contentId, userId) {
 
 var setFromJSON = function(data, userId) {
 	//check if user can set, throw an exception if no deal
-
+	//TODO: check if they are a mod, maybe they can edit anyway...?
+	if (this.author) {
+		if ( (this.author._id && !this.author._id.equals(userId))
+		  || (!this.author._id && this.author.equals(userId) ) ) {
+			throw new UnauthorizedError('You are not the author of that post!');
+		}
+	}
 	this.author 	  = userId;
 	if (data.authorName) this.authorName   = data.authorName;
 	if (data.anonymous)  this.anonymous    = data.anonymous;

--- a/Server/models/common/contentMethods.js
+++ b/Server/models/common/contentMethods.js
@@ -40,6 +40,15 @@ var setAsDeleted = function (contentId, userId) {
 			   });
 }
 
+var setFromJSON = function(data, userId) {
+	//check if user can set, throw an exception if no deal
+
+	this.author 	  = userId;
+	if (data.authorName) this.authorName   = data.authorName;
+	if (data.anonymous)  this.anonymous    = data.anonymous;
+	if (data.message) 	 this.message      = data.message;
+}
+
 var BaseContentSchema = function() {
 
 	mongoose.Schema.apply(this, arguments);
@@ -62,6 +71,9 @@ var BaseContentSchema = function() {
 	this.statics.upVote = upVote;
 	this.statics.downVote = downVote;
 	this.statics.setAsDeleted = setAsDeleted;
+
+	this.methods.setFromJSON = setFromJSON;
+
 	this.plugin(autoPopulate);
 }
 util.inherits(BaseContentSchema, mongoose.Schema);

--- a/Server/models/question.js
+++ b/Server/models/question.js
@@ -31,5 +31,12 @@ questionSchema.index({ downVotes: 1 });
 questionSchema.path('title').index({text : true});
 questionSchema.path('message').index({text : true});
 
+questionSchema.methods.setFromJSON = function(data, userId) {
+	this.__proto__.__proto__.setFromJSON.call(this, data, userId);
+	if (data.title)  this.title		= data.title;
+	if (data.topics) this.topics	= data.topics;
+	if (data.group)  this.group		= data.group;
+}
+
 
 module.exports = contentMethods.BaseContent.discriminator('Question', questionSchema);

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -84,6 +84,7 @@ promisedRouter.put('/questions/downvote/:questionId', questionsCtrl.downVoteQues
 promisedRouter.get('/answers/:questionId', answersCtrl.findByQuestionId);
 promisedRouter.post('/answers/:questionId', answersCtrl.addByQuestionId);
 promisedRouter.delete('/answers/:answerId', answersCtrl.deleteAnswer);
+promisedRouter.put('/answers/:answerId', answersCtrl.updateAnswer);
 promisedRouter.put('/answers/upvote/:answerId', answersCtrl.upVoteAnswer);
 promisedRouter.put('/answers/downvote/:answerId', answersCtrl.downVoteAnswer);
 

--- a/Server/routes/api.js
+++ b/Server/routes/api.js
@@ -49,7 +49,7 @@ function jsonRoute(jsonPromise) {
 		.catch( function(error) {
 			console.error(error.stack);
 			next(error);
-		});
+		})
 	}
 }
 

--- a/Server/server.js
+++ b/Server/server.js
@@ -131,9 +131,12 @@ require(here('/config/socketio'))(server);
 if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
+    console.log(err.message);
+    console.log(err.stack);
     res.json({
       message: err.message,
-      error: err
+      error: err,
+      stack: err.stack
     });
   });
 }


### PR DESCRIPTION
-- implement a generic way of showing error messages to users.
```html
<kusema-server-message message="serverResponse"></kusema-server-message>
```
```js
$http.post(something)
.then(function(yay) { something cool } )
.catch(function(error) { serverResponse = error } )
```
or even more nicely, as all of our api services return promises now:
```js
LoginService.login(username, password)
.then(function() { closeMenu() })
.catch(function(error) { serverResponse = error });
```
Have I mentioned I love promises?
This is currently implemented in the login menu and in the EditContentForm. Still a to do in the comment submission form.

--stop the user menu from closing until login actually completes (this was way way way harder than it should have been, if I were less of a tenacious bastard I think this forum would be up and running in fifty units by now)


-- set server posts from request JSON using a standard method, instead of duplicating it around a bunch of controllers. Beyond a reduction in repeated code, this also lets us do easy authorization...

-- disallow posts from being edited by people who don't own them! implemented in such a way that it should be straightforward to add the capacity for mods to edit.